### PR TITLE
Damp pitchmass oscillations.

### DIFF
--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -13,7 +13,8 @@
         <!-- 146.5671 subtracted by battery mass -->
         <mass>114.8364</mass>
 
-        <!--This is calculated by taking the center of mass and subtractin-->
+        <!-- This is calculated by taking the center of mass and subtracting-->
+        <!-- the center of mass-->
         <pose>0.15444914765060455 0 0 0 0 0</pose>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
@@ -27,7 +28,9 @@
       </inertial>
 
       <collision name="main_body_buoyancy">
-        <pose>0 0 0.007 0 0 0</pose>
+        <!-- This line applies righting moments to the vehicle.
+          Currently set fairly arbitrarily. Supposed to be 0.0017 -->
+        <pose>0 0 -0.02 0 0 0</pose>
         <geometry>
           <box>
             <size>2 0.3 0.245945166667</size>
@@ -237,7 +240,7 @@
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <!-- Non-zero y creates roll. Not fun to tune without actual base link inertia minus battery-->
-        <pose>-0.563 0 0 0 0 0</pose>
+        <pose>-0.563 0 -0.024 0 0 0</pose>
         <mass>31.7307</mass>
         <inertia>
           <ixx>0.2327</ixx>
@@ -360,7 +363,7 @@
 
     <!-- Drop weight -->
     <link name="drop_weight">
-      <pose>0.128 0 0 0 0 0</pose>
+      <pose>0.128 0 -0.142 0 0 0</pose>
       <inertial>
         <mass>1</mass>
         <inertia>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -24,7 +24,9 @@
           <iyz>0</iyz>
           <izz>41.980233</izz-->
 
-          <!-- Guesstimated (decreased by 1/5) to account for battery -->
+          <!-- Taken by adding the inertias of the pressure, tailcone and the
+            nose.
+          -->
           <ixx>1.157</ixx>
           <ixy>0.007</ixy>
           <ixz>0.033</ixz>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -10,9 +10,10 @@
       
       <inertial>
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
-        <!--pose>0 0.0236 0 0 0 0</pose-->
         <!-- 146.5671 subtracted by battery mass -->
         <mass>114.8364</mass>
+
+        <!--This is calculated by taking the center of mass and subtractin-->
         <pose>0.15556377681 0 0 0 0 0</pose>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
@@ -24,18 +25,21 @@
           <izz>41.980233</izz-->
 
           <!-- Guesstimated (decreased by 1/5) to account for battery -->
-          <ixx>2.4</ixx>
-          <ixy>0</ixy>
-          <ixz>0.0004</ixz>
-          <iyy>33.5841864</iyy>
-          <iyz>0</iyz>
-          <izz>33.5841864</izz>
+          <ixx>1.157</ixx>
+          <ixy>0.007</ixy>
+          <ixz>0.033</ixz>
+          <iyx>0.0005</iyx>
+          <iyy>9.65</iyy>
+          <iyz>0.002</iyz>
+          <izx>0.033</izx>
+          <izy>0.002</izy>
+          <izz>9.52</izz>
 
         </inertia>
       </inertial>
 
       <collision name="main_body_buoyancy">
-        <pose>0 0 0.02 0 0 0</pose>
+        <pose>0 0 0.007 0 0 0</pose>
         <geometry>
           <box>
             <size>2 0.3 0.245945166667</size>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -7,11 +7,13 @@
   <model name="tethys">
     <!-- Body -->
     <link name="base_link">
+      
       <inertial>
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
         <!--pose>0 0.0236 0 0 0 0</pose-->
         <!-- 146.5671 subtracted by battery mass -->
         <mass>114.8364</mass>
+        <pose>0.15556377681 0 0 0 0 0</pose>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
           <!--ixx>3.000000</ixx>
@@ -33,7 +35,7 @@
       </inertial>
 
       <collision name="main_body_buoyancy">
-        <pose>0 0 0.007 0 0 0</pose>
+        <pose>0 0 0.02 0 0 0</pose>
         <geometry>
           <box>
             <size>2 0.3 0.245945166667</size>
@@ -243,7 +245,7 @@
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <!-- Non-zero y creates roll. Not fun to tune without actual base link inertia minus battery-->
-        <!--pose>0 -0.0236 0 0 0 0</pose-->
+        <pose>-0.563 0 0 0 0 0</pose>
         <mass>31.7307</mass>
         <inertia>
           <ixx>0.2327</ixx>
@@ -271,10 +273,9 @@
 
     <link name="buoyancy_engine">
       <!-- TODO: Determine location of buoyancy engine -->
-      <pose>0.4 0 0 0 0 0</pose>
+      <pose>0.137 0 0.045 0 0 0</pose>
 
       <inertial>
-        <pose>0 0 0 0 0 0</pose>
         <!-- Ignition requires a mass assigned to the link otherwise weird
         and wonderful segfaults may happen. So we create a neutral buoyancy link
         and then use the plugin to emulate the weight-->
@@ -351,7 +352,7 @@
 
     <!-- positive joint values move mass forward -->
     <joint name="battery_joint" type="prismatic">
-      <pose degrees="true">0 0 0   0 0 180</pose>
+      <pose degrees="true">0 0 0 0 0 180</pose>
       <parent>base_link</parent>
       <child>battery</child>
       <axis>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -14,7 +14,7 @@
         <mass>114.8364</mass>
 
         <!--This is calculated by taking the center of mass and subtractin-->
-        <pose>0.15556377681 0 0 0 0 0</pose>
+        <pose>0.15444914765060455 0 0 0 0 0</pose>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
           <ixx>3.000000</ixx>
@@ -360,7 +360,7 @@
 
     <!-- Drop weight -->
     <link name="drop_weight">
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0.128 0 0 0 0 0</pose>
       <inertial>
         <mass>1</mass>
         <inertia>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -17,26 +17,12 @@
         <pose>0.15556377681 0 0 0 0 0</pose>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
-          <!--ixx>3.000000</ixx>
+          <ixx>3.000000</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
           <iyy>41.980233</iyy>
           <iyz>0</iyz>
-          <izz>41.980233</izz-->
-
-          <!-- Taken by adding the inertias of the pressure, tailcone and the
-            nose.
-          -->
-          <ixx>1.157</ixx>
-          <ixy>0.007</ixy>
-          <ixz>0.033</ixz>
-          <iyx>0.0005</iyx>
-          <iyy>9.65</iyy>
-          <iyz>0.002</iyz>
-          <izx>0.033</izx>
-          <izy>0.002</izy>
-          <izz>9.52</izz>
-
+          <izz>41.980233</izz>
         </inertia>
       </inertial>
 
@@ -376,7 +362,6 @@
     <link name="drop_weight">
       <pose>0 0 0 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.000143971303</ixx>

--- a/lrauv_ignition_plugins/plots/plot_missions.py
+++ b/lrauv_ignition_plugins/plots/plot_missions.py
@@ -130,17 +130,19 @@ def main():
     var = [
       'platform_mass_position',
       'VerticalControl.massPositionAction',
+      'VerticalControl.massPitchErrorInternal',
+      'VerticalControl.pitchCmd',
       'platform_pitch_angle',
     ]
     # Subplot to put each variable
-    varaxs = [0, 0, 1]
+    varaxs = [0, 0, 1, 1, 2]
     # Input data
     timestamps = read_input_list(os.path.join(missions_path, missionName,
       'plot_input_ref.txt'))
     # Legend label for axis [0]
-    lbls = ['state', 'cmd', 'state']
+    lbls = ['state', 'cmd', 'error', 'pitch cmd', 'state']
     # Color for each variable
-    colors = [orange, blue, orange]
+    colors = [orange, blue, orange, blue, orange, blue]
     nPlots = max(varaxs) + 1
 
   # Mass shifter + VBS

--- a/lrauv_ignition_plugins/plots/unserialize_for_plotting.sh
+++ b/lrauv_ignition_plugins/plots/unserialize_for_plotting.sh
@@ -107,6 +107,8 @@ echo ""
 cmd="$lrauv_app_path/bin/unserialize -c ${latest}/slate \
   depth \
   VerticalControl.depthCmd \
+  VerticalControl.pitchCmd \
+  VerticalControl.massPitchErrorInternal\
   platform_propeller_rotation_rate \
   SpeedControl.propOmegaAction \
   platform_buoyancy_position \


### PR DESCRIPTION
This PR submits 2 changes. The first is to shift the center of mass of the baselink back and move the center of mass of the vehicle forward. This helps resolve some of the spinning in #47. It also is based on the actual positions of the robot.

The second change made is an increase in distance between the linkand the center of volume. This helps damp oscillations when running `testPitchMass.xml`.

Additionally, this commit updates the pitchmass plots to contain the Error as well as the current Pitch command.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>