### PR TITLE
[QOL improvement] Exit if the docker image does not build

### DIFF
--- a/docker/debug_integration.sh
+++ b/docker/debug_integration.sh
@@ -57,6 +57,10 @@ fi
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 cd $DIR
+
+# exit if the docker image doesn't build
+set -e
+
 # Build the docker image
 docker build -t mbari_lrauv_debug -f $DIR/debug_integration/Dockerfile ..
 


### PR DESCRIPTION
This PR adds a `set -e` command to make sure the script exits if the source fails to build for some reason. The previous behaviour was annoying as it would execute the last good image, this leads to a lot of confusion when debugging.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>