### PR TITLE
Relax spawn tight tolerance

### DIFF
--- a/lrauv_ignition_plugins/test/test_spawn.cc
+++ b/lrauv_ignition_plugins/test/test_spawn.cc
@@ -143,7 +143,7 @@ TEST(SpawnTest, Spawn)
   // FIXME(anyone): Ideally all axes would have a tight tolerance, but depth
   // and pitch are currently unstable, see
   // https://github.com/osrf/lrauv/issues/49
-  double tightTol{1e-6};
+  double tightTol{1e-5};
   double depthTol{1e-2};
   double pitchTol{1e-2};
 


### PR DESCRIPTION
I was too ambitious on #61, the current tight tolerance is flaky, see [failure](https://github.com/osrf/lrauv/runs/4113119416?check_suite_focus=true)

```
2021-11-05T03:25:43.8355456Z 9: /home/developer/lrauv_ws/src/lrauv/lrauv_ignition_plugins/test/test_spawn.cc:161: Failure
2021-11-05T03:25:43.8356431Z 9: The difference between 0.0 and poses1.back().Pos().X() is 2.1789064913657771e-06, which exceeds tightTol, where
2021-11-05T03:25:43.8356995Z 9: 0.0 evaluates to 0,
2021-11-05T03:25:43.8357586Z 9: poses1.back().Pos().X() evaluates to -2.1789064913657771e-06, and
2021-11-05T03:25:43.8358198Z 9: tightTol evaluates to 9.9999999999999995e-07.
```