### PR TITLE
Strip and add back components

### DIFF
--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -9,7 +9,7 @@
     <link name="base_link">
       <inertial>
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
-        <pose>-0.1181 0 0 0 0 0</pose>
+        <pose>-0.119779049 0 0 0 0 0</pose>
         <!-- 146.5671 subtracted by battery mass -->
         <!--<mass>114.8364</mass>-->
         <mass>146.5671</mass>
@@ -377,16 +377,12 @@
 
     <!-- Drop weight -->
     <link name="drop_weight">
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0.128 0 -0.142 0 0 0</pose>
       <inertial>
-        <pose>0 0 0 0 0 0</pose>
         <mass>1</mass>
         <inertia>
           <ixx>0.000143971303</ixx>
-          <ixy>0.000000000008</ixy>
-          <ixz>-0.000000000224</ixz>
           <iyy>0.000140915448</iyy>
-          <iyz>-0.000025236433</iyz>
           <izz>0.000033571862</izz>
         </inertia>
       </inertial>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -11,23 +11,23 @@
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
         <!--pose>0 0.0236 0 0 0 0</pose-->
         <!-- 146.5671 subtracted by battery mass -->
-        <mass>114.8364</mass>
+        <!--<mass>114.8364</mass>-->
+        <mass>147.5671</mass>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
-          <!--ixx>3.000000</ixx>
+          <ixx>3.000000</ixx>
           <ixy>0</ixy>
           <ixz>0</ixz>
           <iyy>41.980233</iyy>
           <iyz>0</iyz>
-          <izz>41.980233</izz-->
-
+          <izz>41.980233</izz>
           <!-- Guesstimated (decreased by 1/5) to account for battery -->
-          <ixx>2.4</ixx>
+          <!--<ixx>2.4</ixx>
           <ixy>0</ixy>
           <ixz>0.0004</ixz>
           <iyy>33.5841864</iyy>
           <iyz>0</iyz>
-          <izz>33.5841864</izz>
+          <izz>33.5841864</izz>-->
 
         </inertia>
       </inertial>
@@ -37,6 +37,7 @@
         <geometry>
           <box>
             <size>2 0.3 0.245945166667</size>
+            <!--<size>2 0.2 0.36891775</size>-->
           </box>
         </geometry>
       </collision>
@@ -72,7 +73,7 @@
     </link>
 
     <!-- Horizontal fins -->
-    <link name="horizontal_fins">
+    <!--<link name="horizontal_fins">
       <pose>1.05 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 1.57 0 0.5</pose>
@@ -124,10 +125,10 @@
           </script>
         </material>
       </visual>
-    </link>
+    </link>-->
 
     <!-- Vertical fins -->
-    <link name="vertical_fins">
+    <!--<link name="vertical_fins">
       <pose>1.05 0 0 0 0 0</pose>
       <inertial>
         <mass>0.2</mass>
@@ -178,10 +179,10 @@
           </script>
         </material>
       </visual>
-    </link>
+    </link>-->
 
     <!-- Propeller -->
-    <link name="propeller">
+    <!--<link name="propeller">
       <pose>1.43162 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 1.570796 0 0</pose>
@@ -233,18 +234,18 @@
           </script>
         </material>
       </visual>
-    </link>
+    </link>-->
 
     <!-- Battery -->
     <!-- No separate collision for battery, because it is inside the vehicle.
          Additional collision requires buoyancy volume recalculation. -->
-    <link name="battery">
-      <!-- TODO: On hold till mesh center adjusted to aft dome, then it will be 0.563, 0, 0.024. -->
+     <!--<link name="battery">
+      TODO: On hold till mesh center adjusted to aft dome, then it will be 0.563, 0, 0.024.
       <pose>0 0 0 0 0 0</pose>
-      <inertial>
+      <inertial>-->
         <!-- Non-zero y creates roll. Not fun to tune without actual base link inertia minus battery-->
         <!--pose>0 -0.0236 0 0 0 0</pose-->
-        <mass>31.7307</mass>
+        <!--<mass>31.7307</mass>
         <inertia>
           <ixx>0.2327</ixx>
           <ixy>0</ixy>
@@ -257,9 +258,9 @@
 
       <visual name= "visual">
         <geometry>
-          <box>
+          <box>-->
             <!-- z is guesstimated from schematics. Visual doesn't matter. -->
-            <size>0.6489446 0.24638 0.17415</size>
+            <!--<size>0.6489446 0.24638 0.17415</size>
           </box>
         </geometry>
         <material>
@@ -267,11 +268,11 @@
           <specular>0.0 0.0 1.0 1.0</specular>
         </material>
       </visual>
-    </link>
+    </link>-->
 
-    <link name="buoyancy_engine">
+    <!--<link name="buoyancy_engine">-->
       <!-- TODO: Determine location of buoyancy engine -->
-      <pose>0.4 0 0 0 0 0</pose>
+      <!--<pose>0.4 0 0 0 0 0</pose>-->
 
       <!-- TODO: Remove inertial and collision
 
@@ -285,7 +286,7 @@
          (why?), so removing them makes the vehicle unstable.
 
       -->
-      <inertial>
+      <!--<inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.3</mass>
         <inertia>
@@ -304,10 +305,10 @@
           </box>
         </geometry>
       </collision>
-    </link>
+    </link>-->
 
     <!-- Joints -->
-    <joint name="buoyancy_engine_joint" type="fixed">
+    <!--<joint name="buoyancy_engine_joint" type="fixed">
       <pose>0 0 0 0 0 0</pose>
       <parent>base_link</parent>
       <child>buoyancy_engine</child>
@@ -356,10 +357,10 @@
           <velocity>-1</velocity>
         </limit>
       </axis>
-    </joint>
+    </joint>-->
 
     <!-- positive joint values move mass forward -->
-    <joint name="battery_joint" type="prismatic">
+    <!--<joint name="battery_joint" type="prismatic">
       <pose degrees="true">0 0 0   0 0 180</pose>
       <parent>base_link</parent>
       <child>battery</child>
@@ -372,10 +373,10 @@
           <velocity>0.0007</velocity>
         </limit>
       </axis>
-    </joint>
+    </joint>-->
 
     <!-- Drop weight -->
-    <link name="drop_weight">
+    <!--<link name="drop_weight">
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
@@ -389,7 +390,7 @@
           <izz>0.000033571862</izz>
         </inertia>
       </inertial>
-    </link>
+    </link>-->
 
   </model>
 </sdf>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -9,7 +9,7 @@
     <link name="base_link">
       <inertial>
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
-        <!--pose>0 0.0236 0 0 0 0</pose-->
+        <pose>-0.1181 0 0 0 0 0</pose>
         <!-- 146.5671 subtracted by battery mass -->
         <!--<mass>114.8364</mass>-->
         <mass>147.5671</mass>
@@ -33,7 +33,7 @@
       </inertial>
 
       <collision name="main_body_buoyancy">
-        <pose>0 0 0.007 0 0 0</pose>
+        <pose>-0.1181 0 0.007 0 0 0</pose>
         <geometry>
           <box>
             <size>2 0.3 0.245945166667</size>

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -11,8 +11,8 @@
         <!-- to offset battery CoM before getting real parameters for vehicle without battery -->
         <pose>-0.119779049 0 0 0 0 0</pose>
         <!-- 146.5671 subtracted by battery mass -->
-        <!--<mass>114.8364</mass>-->
-        <mass>146.5671</mass>
+        <mass>114.8364</mass>
+        <!--<mass>146.5671</mass>-->
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
           <ixx>3.000000</ixx>
@@ -239,13 +239,14 @@
     <!-- Battery -->
     <!-- No separate collision for battery, because it is inside the vehicle.
          Additional collision requires buoyancy volume recalculation. -->
-     <!--<link name="battery">
-      TODO: On hold till mesh center adjusted to aft dome, then it will be 0.563, 0, 0.024.
-      <pose>0 0 0 0 0 0</pose>
-      <inertial>-->
+     <link name="battery">
+      <!--TODO: On hold till mesh center adjusted to aft dome, then it will be 0.563, 0, 0.024.-->
+      
+      <inertial>
         <!-- Non-zero y creates roll. Not fun to tune without actual base link inertia minus battery-->
         <!--pose>0 -0.0236 0 0 0 0</pose-->
-        <!--<mass>31.7307</mass>
+        <pose>-0.119779049 0 0 0 0 0</pose>
+        <mass>31.7307</mass>
         <inertia>
           <ixx>0.2327</ixx>
           <ixy>0</ixy>
@@ -258,9 +259,9 @@
 
       <visual name= "visual">
         <geometry>
-          <box>-->
+          <box>
             <!-- z is guesstimated from schematics. Visual doesn't matter. -->
-            <!--<size>0.6489446 0.24638 0.17415</size>
+            <size>0.6489446 0.24638 0.17415</size>
           </box>
         </geometry>
         <material>
@@ -268,7 +269,7 @@
           <specular>0.0 0.0 1.0 1.0</specular>
         </material>
       </visual>
-    </link>-->
+    </link>
 
     <!--<link name="buoyancy_engine">-->
       <!-- TODO: Determine location of buoyancy engine -->
@@ -360,7 +361,7 @@
     </joint>-->
 
     <!-- positive joint values move mass forward -->
-    <!--<joint name="battery_joint" type="prismatic">
+    <joint name="battery_joint" type="prismatic">
       <pose degrees="true">0 0 0   0 0 180</pose>
       <parent>base_link</parent>
       <child>battery</child>
@@ -373,7 +374,7 @@
           <velocity>0.0007</velocity>
         </limit>
       </axis>
-    </joint>-->
+    </joint>
 
     <!-- Drop weight -->
     <link name="drop_weight">

--- a/lrauv_description/models/tethys/model.sdf
+++ b/lrauv_description/models/tethys/model.sdf
@@ -12,7 +12,7 @@
         <pose>-0.1181 0 0 0 0 0</pose>
         <!-- 146.5671 subtracted by battery mass -->
         <!--<mass>114.8364</mass>-->
-        <mass>147.5671</mass>
+        <mass>146.5671</mass>
         <!-- TODO: Get inertial matrix of base link WITHOUT battery -->
         <inertia>
           <ixx>3.000000</ixx>
@@ -376,7 +376,7 @@
     </joint>-->
 
     <!-- Drop weight -->
-    <!--<link name="drop_weight">
+    <link name="drop_weight">
       <pose>0 0 0 0 0 0</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
@@ -390,7 +390,7 @@
           <izz>0.000033571862</izz>
         </inertia>
       </inertial>
-    </link>-->
+    </link>
 
   </model>
 </sdf>

--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -9,7 +9,7 @@
       <uri>tethys</uri>
 
       <!-- Sensors -->
-      <experimental:params>
+      <!--<experimental:params>
         <sensor
           element_id="base_link"
           action="add"
@@ -74,9 +74,9 @@
             </noise>
           </ignition:current>
         </sensor>
-      </experimental:params>
+      </experimental:params>-->
       <!-- Joint controllers -->
-      <plugin
+      <!--<plugin
         filename="ignition-gazebo-joint-position-controller-system"
         name="ignition::gazebo::systems::JointPositionController">
         <joint_name>horizontal_fins_joint</joint_name>
@@ -104,10 +104,10 @@
         <joint_name>battery_joint</joint_name>
         <use_velocity_commands>true</use_velocity_commands>
         <cmd_max>0.0007</cmd_max>
-      </plugin>
+      </plugin>-->
       <!-- Lift and drag -->
       <!-- Vertical fin -->
-      <plugin
+      <!--<plugin
         filename="ignition-gazebo-lift-drag-system"
         name="ignition::gazebo::systems::LiftDrag">
         <air_density>1000</air_density>
@@ -117,16 +117,16 @@
         <cda_stall>0.03</cda_stall>
         <alpha_stall>0.17</alpha_stall>
         <a0>0</a0>
-        <area>0.0244</area>
+        <area>0.0244</area>-->
         <!-- Link's Y is perpendicular to the control surface -->
-        <upward>0 1 0</upward>
+        <!--<upward>0 1 0</upward>-->
         <!-- Link's X is pointing towards the back -->
-        <forward>-1 0 0</forward>
+        <!--<forward>-1 0 0</forward>
         <link_name>vertical_fins</link_name>
         <cp>0 0 0</cp>
-      </plugin>
+      </plugin>-->
       <!-- Horizontal fin -->
-      <plugin
+      <!--<plugin
         filename="ignition-gazebo-lift-drag-system"
         name="ignition::gazebo::systems::LiftDrag">
         <air_density>1000</air_density>
@@ -136,24 +136,24 @@
         <cda_stall>0.03</cda_stall>
         <alpha_stall>0.17</alpha_stall>
         <a0>0</a0>
-        <area>0.0244</area>
+        <area>0.0244</area>-->
         <!-- Link's Z is perpendicular to the control surface -->
-        <upward>0 0 1</upward>
+        <!--<upward>0 0 1</upward>-->
         <!-- Link's X is pointing towards the back -->
-        <forward>-1 0 0</forward>
+        <!--<forward>-1 0 0</forward>
         <link_name>horizontal_fins</link_name>
         <cp>0 0 0</cp>
-      </plugin>
+      </plugin>-->
       <!-- Interface with LRAUV Main Vehicle Application for each vehicle -->
-      <plugin
+      <!--<plugin
         filename="TethysCommPlugin"
         name="tethys::TethysCommPlugin">
         <namespace>tethys</namespace>
         <command_topic>tethys/command_topic</command_topic>
         <state_topic>tethys/state_topic</state_topic>
         <debug_printout>0</debug_printout>
-      </plugin>
-      <plugin
+      </plugin>-->
+      <!--<plugin
         filename="HydrodynamicsPlugin"
         name="tethys::HydrodynamicsPlugin">
         <link_name>base_link</link_name>
@@ -176,23 +176,23 @@
         <mQ>0</mQ>
         <nRR>-632.698957</nRR>
         <nR>0</nR>
-      </plugin>
-      <plugin
+      </plugin>-->
+      <!--<plugin
         filename="ignition-gazebo-buoyancy-engine-system"
         name="ignition::gazebo::v6::systems::BuoyancyEnginePlugin">
         <link_name>buoyancy_engine</link_name>
         <namespace>tethys</namespace>
-        <fluid_density>1000</fluid_density>
+        <fluid_density>1000</fluid_density>-->
         <!-- 80 cc == 0.00008 m^3 -->
-        <min_volume>0.000080</min_volume>
+        <!--<min_volume>0.000080</min_volume>-->
         <!-- 500 cc == 0.0005 m^3 -->
-        <neutral_volume>0.0005</neutral_volume>
-        <default_volume>0.0005</default_volume>
+        <!--<neutral_volume>0.0005</neutral_volume>-->
+        <!--<default_volume>0.0005</default_volume>-->
         <!-- 955 cc == 0.000955 m^3 -->
-        <max_volume>0.000955</max_volume>
+        <!--<max_volume>0.000955</max_volume>-->
         <!-- m^3/s -->
-        <max_inflation_rate>0.000003</max_inflation_rate>
-      </plugin>
+        <!--<max_inflation_rate>0.000003</max_inflation_rate>
+      </plugin>-->
       <plugin
         filename="ignition-gazebo-detachable-joint-system"
         name="ignition::gazebo::systems::DetachableJoint">
@@ -202,7 +202,7 @@
         <topic>/model/tethys/drop_weight</topic>
       </plugin>
 
-      <plugin
+      <!--<plugin
         filename="AcousticCommsPlugin"
         name="tethys::AcousticCommsPlugin">
         <address>1</address>
@@ -221,7 +221,7 @@
         <speed_of_sound>1500</speed_of_sound>
         <link_name>base_link</link_name>
         <namespace>tethys</namespace>
-      </plugin>
+      </plugin>-->
 
     </include>
   </model>

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -5,6 +5,7 @@
 -->
 <sdf version="1.6">
   <world name="buoyant_tethys">
+    <gravity>0 0 -9.8</gravity>
     <scene>
       <!-- For turquoise ambient to match particle effect -->
       <ambient>0.0 1.0 1.0</ambient>
@@ -53,16 +54,8 @@
           <density>1</density>
         </density_change>
       </graded_buoyancy-->
+      <uniform_fluid_density>1000</uniform_fluid_density>
     </plugin>
-
-    <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
-      to ParticleEmitter in Ignition G.
-      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
-    <plugin
-      filename="ignition-gazebo-particle-emitter2-system"
-      name="ignition::gazebo::systems::ParticleEmitter2">
-    </plugin>
-
     <!-- Uncomment for time analysis -->
     <!--plugin
       filename="TimeAnalysisPlugin"
@@ -306,7 +299,7 @@
 
     <include>
       <pose>0 0 0 0 0 0</pose>
-      <uri>tethys_equipped</uri>
+      <uri>tethys</uri>
     </include>
 
   </world>

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -299,7 +299,7 @@
 
     <include>
       <pose>0 0 0 0 0 0</pose>
-      <uri>tethys</uri>
+      <uri>tethys_equipped</uri>
     </include>
 
   </world>


### PR DESCRIPTION
This is a "live blog" of myself trying to strip the vehicle down and add components in to determine the cause of the oscillations in the vehicle. The rationale for doing this is to make sure that we can isolate the systems responsible for Hydrostatic instability. I will start with a rigid body with an off-center mass. 

Right now only the buoyancy plugin is enabled.

Requires https://github.com/ignitionrobotics/ign-gazebo/issues/1211

The vehicle in cd7990ae4c8fdd21b9774fb84f8318dbf57b1101 is stable with no oscillation.