### PR TITLE
Suggestions to #70

### DIFF
--- a/lrauv_ignition_plugins/src/VisualizePointCloud.cc
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.cc
@@ -118,7 +118,7 @@ namespace tethys
     public: float minFloatV{std::numeric_limits<float>::max()};
 
     /// \brief Maximum value in latest float vector
-    public: float maxFloatV{std::numeric_limits<float>::min()};
+    public: float maxFloatV{-std::numeric_limits<float>::max()};
 
     /// \brief Color for minimum value
     public: ignition::math::Color minColor{255, 0, 0, 255};
@@ -317,6 +317,9 @@ void VisualizePointCloud::OnFloatV(const ignition::msgs::Float_V &_msg)
 {
   std::lock_guard<std::recursive_mutex>(this->dataPtr->mutex);
   this->dataPtr->floatVMsg = _msg;
+
+  this->dataPtr->minFloatV = std::numeric_limits<float>::max();
+  this->dataPtr->maxFloatV = -std::numeric_limits<float>::max();
 
   for (auto i = 0; i < _msg.data_size(); ++i)
   {

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.hh
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.hh
@@ -55,6 +55,38 @@ namespace tethys
       NOTIFY FloatVTopicListChanged
     )
 
+    /// \brief Color for minimum value
+    Q_PROPERTY(
+      QColor minColor
+      READ MinColor
+      WRITE SetMinColor
+      NOTIFY MinColorChanged
+    )
+
+    /// \brief Color for maximum value
+    Q_PROPERTY(
+      QColor maxColor
+      READ MaxColor
+      WRITE SetMaxColor
+      NOTIFY MaxColorChanged
+    )
+
+    /// \brief Minimum value
+    Q_PROPERTY(
+      float minFloatV
+      READ MinFloatV
+      WRITE SetMinFloatV
+      NOTIFY MinFloatVChanged
+    )
+
+    /// \brief Maximum value
+    Q_PROPERTY(
+      float maxFloatV
+      READ MaxFloatV
+      WRITE SetMaxFloatV
+      NOTIFY MaxFloatVChanged
+    )
+
     /// \brief Constructor
     public: VisualizePointCloud();
 
@@ -115,6 +147,50 @@ namespace tethys
     /// \brief Set topic to subscribe to for float vectors.
     /// \param[in] _topicName Name of selected topic
     public: Q_INVOKABLE void OnFloatVTopic(const QString &_topicName);
+
+    /// \brief Get the minimum color
+    /// \return Minimum color
+    public: Q_INVOKABLE QColor MinColor() const;
+
+    /// \brief Set the minimum color
+    /// \param[in] _minColor Minimum color.
+    public: Q_INVOKABLE void SetMinColor(const QColor &_minColor);
+
+    /// \brief Notify that minimum color has changed
+    signals: void MinColorChanged();
+
+    /// \brief Get the maximum color
+    /// \return Maximum color
+    public: Q_INVOKABLE QColor MaxColor() const;
+
+    /// \brief Set the maximum color
+    /// \param[ax] _maxColor Maximum color.
+    public: Q_INVOKABLE void SetMaxColor(const QColor &_maxColor);
+
+    /// \brief Notify that maximum color has changed
+    signals: void MaxColorChanged();
+
+    /// \brief Get the minimum value
+    /// \return Minimum value
+    public: Q_INVOKABLE float MinFloatV() const;
+
+    /// \brief Set the minimum value
+    /// \param[in] _minFloatV Minimum value.
+    public: Q_INVOKABLE void SetMinFloatV(float _minFloatV);
+
+    /// \brief Notify that minimum value has changed
+    signals: void MinFloatVChanged();
+
+    /// \brief Get the maximum value
+    /// \return Maximum value
+    public: Q_INVOKABLE float MaxFloatV() const;
+
+    /// \brief Set the maximum value
+    /// \param[ax] _maxFloatV Maximum value.
+    public: Q_INVOKABLE void SetMaxFloatV(float _maxFloatV);
+
+    /// \brief Notify that maximum value has changed
+    signals: void MaxFloatVChanged();
 
     /// \brief Set whether to show the point cloud.
     /// \param[in] _show Boolean value for displaying the points.

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.hh
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.hh
@@ -41,10 +41,18 @@ namespace tethys
 
     /// \brief List of topics publishing PointCloudPacked messages
     Q_PROPERTY(
-      QStringList topicList
-      READ TopicList
-      WRITE SetTopicList
-      NOTIFY TopicListChanged
+      QStringList pointCloudTopicList
+      READ PointCloudTopicList
+      WRITE SetPointCloudTopicList
+      NOTIFY PointCloudTopicListChanged
+    )
+
+    /// \brief List of topics publishing FloatV messages
+    Q_PROPERTY(
+      QStringList floatVTopicList
+      READ FloatVTopicList
+      WRITE SetFloatVTopicList
+      NOTIFY FloatVTopicListChanged
     )
 
     /// \brief Constructor
@@ -56,36 +64,57 @@ namespace tethys
     // Documentation inherited
     public: void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
 
-    /// \brief Callback function to get data from the message
+    /// \brief Callback function for point cloud topic.
     /// \param[in]_msg Point cloud message
-    public: void OnCloud(const ignition::msgs::PointCloudPacked &_msg);
+    public: void OnPointCloud(const ignition::msgs::PointCloudPacked &_msg);
 
-    // TODO TEMPORARY HACK float arrays instead of point cloud fields
-    public: void OnTemperature(const ignition::msgs::Float_V &_msg);
-    public: void OnChlorophyll(const ignition::msgs::Float_V &_msg);
-    public: void OnSalinity(const ignition::msgs::Float_V &_msg);
-    public: void OnFloatData(const ignition::msgs::Float_V &_msg);
-
-    /// \brief Callback function to get data from the message
+    /// \brief Callback function for point cloud service
     /// \param[in]_msg Point cloud message
     /// \param[out]_result True on success.
-    public: void OnService(const ignition::msgs::PointCloudPacked &_msg,
-        bool _result);
+    public: void OnPointCloudService(
+        const ignition::msgs::PointCloudPacked &_msg, bool _result);
 
     /// \brief Get the topic list
     /// \return List of topics
-    public: Q_INVOKABLE QStringList TopicList() const;
+    public: Q_INVOKABLE QStringList PointCloudTopicList() const;
 
     /// \brief Set the topic list from a string
-    /// \param[in] _topicList List of topics.
-    public: Q_INVOKABLE void SetTopicList(const QStringList &_topicList);
+    /// \param[in] _pointCloudTopicList List of topics.
+    public: Q_INVOKABLE void SetPointCloudTopicList(
+        const QStringList &_pointCloudTopicList);
 
     /// \brief Notify that topic list has changed
-    signals: void TopicListChanged();
+    signals: void PointCloudTopicListChanged();
 
-    /// \brief Set topic to subscribe to.
+    /// \brief Set topic to subscribe to for point cloud.
     /// \param[in] _topicName Name of selected topic
-    public: Q_INVOKABLE void OnTopic(const QString &_topicName);
+    public: Q_INVOKABLE void OnPointCloudTopic(const QString &_topicName);
+
+    /// \brief Callback function for float vector topic.
+    /// \param[in]_msg Float vector message
+    public: void OnFloatV(const ignition::msgs::Float_V &_msg);
+
+    /// \brief Callback function for point cloud service
+    /// \param[in]_msg Float vector message
+    /// \param[out]_result True on success.
+    public: void OnFloatVService(
+        const ignition::msgs::Float_V &_msg, bool _result);
+
+    /// \brief Get the topic list
+    /// \return List of topics
+    public: Q_INVOKABLE QStringList FloatVTopicList() const;
+
+    /// \brief Set the topic list from a string
+    /// \param[in] _floatVTopicList List of topics.
+    public: Q_INVOKABLE void SetFloatVTopicList(
+        const QStringList &_floatVTopicList);
+
+    /// \brief Notify that topic list has changed
+    signals: void FloatVTopicListChanged();
+
+    /// \brief Set topic to subscribe to for float vectors.
+    /// \param[in] _topicName Name of selected topic
+    public: Q_INVOKABLE void OnFloatVTopic(const QString &_topicName);
 
     /// \brief Set whether to show the point cloud.
     /// \param[in] _show Boolean value for displaying the points.

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.qml
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.qml
@@ -31,7 +31,7 @@ GridLayout {
   columns: 6
   columnSpacing: 10
   Layout.minimumWidth: 350
-  Layout.minimumHeight: 200
+  Layout.minimumHeight: 300
   anchors.fill: parent
   anchors.leftMargin: 10
   anchors.rightMargin: 10
@@ -102,6 +102,90 @@ GridLayout {
     ToolTip.visible: hovered
     ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
     ToolTip.text: qsTr("Ignition transport topics publishing FloatV messages")
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    text: "Min"
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    Layout.maximumWidth: 50
+    text: VisualizePointCloud.minFloatV.toFixed(2)
+    elide: Text.ElideRight
+  }
+
+  Button {
+    Layout.columnSpan: 1
+    id: minColorButton
+    Layout.fillWidth: true
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Color for minimum value")
+    onClicked: minColorDialog.open()
+    background: Rectangle {
+      implicitWidth: 40
+      implicitHeight: 40
+      radius: 5
+      border.color: VisualizePointCloud.minColor
+      border.width: 2
+      color: VisualizePointCloud.minColor
+    }
+    ColorDialog {
+      id: minColorDialog
+      title: "Choose a color for the minimum value"
+      visible: false
+      onAccepted: {
+        VisualizePointCloud.SetMinColor(minColorDialog.color)
+        minColorDialog.close()
+      }
+      onRejected: {
+        minColorDialog.close()
+      }
+    }
+  }
+
+  Button {
+    Layout.columnSpan: 1
+    id: maxColorButton
+    Layout.fillWidth: true
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Color for maximum value")
+    onClicked: maxColorDialog.open()
+    background: Rectangle {
+      implicitWidth: 40
+      implicitHeight: 40
+      radius: 5
+      border.color: VisualizePointCloud.maxColor
+      border.width: 2
+      color: VisualizePointCloud.maxColor
+    }
+    ColorDialog {
+      id: maxColorDialog
+      title: "Choose a color for the maximum value"
+      visible: false
+      onAccepted: {
+        VisualizePointCloud.SetMaxColor(maxColorDialog.color)
+        maxColorDialog.close()
+      }
+      onRejected: {
+        maxColorDialog.close()
+      }
+    }
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    Layout.maximumWidth: 50
+    text: VisualizePointCloud.maxFloatV.toFixed(2)
+    elide: Text.ElideRight
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    text: "Max"
   }
 
   Item {

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.qml
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.qml
@@ -36,15 +36,14 @@ GridLayout {
   anchors.leftMargin: 10
   anchors.rightMargin: 10
 
-  // TODO Use switch
-  CheckBox {
+  Switch {
     Layout.alignment: Qt.AlignHCenter
     id: displayVisual
-    Layout.columnSpan: 6
+    Layout.columnSpan: 5
     Layout.fillWidth: true
     text: qsTr("Show")
     checked: true
-    onClicked: {
+    onToggled: {
       VisualizePointCloud.Show(checked)
     }
   }
@@ -54,30 +53,55 @@ GridLayout {
     text: "\u21bb"
     Material.background: Material.primary
     onClicked: {
-      combo.currentIndex = 0
       VisualizePointCloud.OnRefresh();
+      pcCombo.currentIndex = 0
+      floatCombo.currentIndex = 0
     }
     ToolTip.visible: hovered
-    ToolTip.delay: tooltipDelay
-    ToolTip.timeout: tooltipTimeout
-    ToolTip.text: qsTr("Refresh list of topics publishing point clouds")
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Refresh list of topics publishing point clouds and float vectors")
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    text: "Point cloud"
   }
 
   ComboBox {
     Layout.columnSpan: 5
-    id: combo
+    id: pcCombo
     Layout.fillWidth: true
-    model: VisualizePointCloud.topicList
+    model: VisualizePointCloud.pointCloudTopicList
     currentIndex: 0
     onCurrentIndexChanged: {
       if (currentIndex < 0)
         return;
-      VisualizePointCloud.OnTopic(textAt(currentIndex));
+      VisualizePointCloud.OnPointCloudTopic(textAt(currentIndex));
     }
     ToolTip.visible: hovered
-    ToolTip.delay: tooltipDelay
-    ToolTip.timeout: tooltipTimeout
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
     ToolTip.text: qsTr("Ignition transport topics publishing PointCloudPacked messages")
+  }
+
+  Label {
+    Layout.columnSpan: 1
+    text: "Float vector"
+  }
+
+  ComboBox {
+    Layout.columnSpan: 5
+    id: floatCombo
+    Layout.fillWidth: true
+    model: VisualizePointCloud.floatVTopicList
+    currentIndex: 0
+    onCurrentIndexChanged: {
+      if (currentIndex < 0)
+        return;
+      VisualizePointCloud.OnFloatVTopic(textAt(currentIndex));
+    }
+    ToolTip.visible: hovered
+    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+    ToolTip.text: qsTr("Ignition transport topics publishing FloatV messages")
   }
 
   Item {

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.qml
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.qml
@@ -27,165 +27,180 @@ import QtQuick.Controls.Material 2.1
 import QtQuick.Layouts 1.3
 import "qrc:/qml"
 
-GridLayout {
-  columns: 6
-  columnSpacing: 10
+ColumnLayout {
+  spacing: 10
   Layout.minimumWidth: 350
   Layout.minimumHeight: 300
   anchors.fill: parent
   anchors.leftMargin: 10
   anchors.rightMargin: 10
 
-  Switch {
-    Layout.alignment: Qt.AlignHCenter
-    id: displayVisual
-    Layout.columnSpan: 5
+  RowLayout {
+    spacing: 10
     Layout.fillWidth: true
-    text: qsTr("Show")
-    checked: true
-    onToggled: {
-      VisualizePointCloud.Show(checked)
-    }
-  }
 
-  RoundButton {
-    Layout.columnSpan: 1
-    text: "\u21bb"
-    Material.background: Material.primary
-    onClicked: {
-      VisualizePointCloud.OnRefresh();
-      pcCombo.currentIndex = 0
-      floatCombo.currentIndex = 0
-    }
-    ToolTip.visible: hovered
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Refresh list of topics publishing point clouds and float vectors")
-  }
-
-  Label {
-    Layout.columnSpan: 1
-    text: "Point cloud"
-  }
-
-  ComboBox {
-    Layout.columnSpan: 5
-    id: pcCombo
-    Layout.fillWidth: true
-    model: VisualizePointCloud.pointCloudTopicList
-    currentIndex: 0
-    onCurrentIndexChanged: {
-      if (currentIndex < 0)
-        return;
-      VisualizePointCloud.OnPointCloudTopic(textAt(currentIndex));
-    }
-    ToolTip.visible: hovered
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Ignition transport topics publishing PointCloudPacked messages")
-  }
-
-  Label {
-    Layout.columnSpan: 1
-    text: "Float vector"
-  }
-
-  ComboBox {
-    Layout.columnSpan: 5
-    id: floatCombo
-    Layout.fillWidth: true
-    model: VisualizePointCloud.floatVTopicList
-    currentIndex: 0
-    onCurrentIndexChanged: {
-      if (currentIndex < 0)
-        return;
-      VisualizePointCloud.OnFloatVTopic(textAt(currentIndex));
-    }
-    ToolTip.visible: hovered
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Ignition transport topics publishing FloatV messages")
-  }
-
-  Label {
-    Layout.columnSpan: 1
-    text: "Min"
-  }
-
-  Label {
-    Layout.columnSpan: 1
-    Layout.maximumWidth: 50
-    text: VisualizePointCloud.minFloatV.toFixed(2)
-    elide: Text.ElideRight
-  }
-
-  Button {
-    Layout.columnSpan: 1
-    id: minColorButton
-    Layout.fillWidth: true
-    ToolTip.visible: hovered
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Color for minimum value")
-    onClicked: minColorDialog.open()
-    background: Rectangle {
-      implicitWidth: 40
-      implicitHeight: 40
-      radius: 5
-      border.color: VisualizePointCloud.minColor
-      border.width: 2
-      color: VisualizePointCloud.minColor
-    }
-    ColorDialog {
-      id: minColorDialog
-      title: "Choose a color for the minimum value"
-      visible: false
-      onAccepted: {
-        VisualizePointCloud.SetMinColor(minColorDialog.color)
-        minColorDialog.close()
-      }
-      onRejected: {
-        minColorDialog.close()
+    Switch {
+      Layout.alignment: Qt.AlignHCenter
+      id: displayVisual
+      Layout.columnSpan: 5
+      Layout.fillWidth: true
+      text: qsTr("Show")
+      checked: true
+      onToggled: {
+        VisualizePointCloud.Show(checked)
       }
     }
+
+    RoundButton {
+      Layout.columnSpan: 1
+      text: "\u21bb"
+      Material.background: Material.primary
+      onClicked: {
+        VisualizePointCloud.OnRefresh();
+        pcCombo.currentIndex = 0
+        floatCombo.currentIndex = 0
+      }
+      ToolTip.visible: hovered
+      ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+      ToolTip.text: qsTr("Refresh list of topics publishing point clouds and float vectors")
+    }
   }
 
-  Button {
-    Layout.columnSpan: 1
-    id: maxColorButton
+  GridLayout {
+    columns: 3
+    columnSpacing: 10
     Layout.fillWidth: true
-    ToolTip.visible: hovered
-    ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
-    ToolTip.text: qsTr("Color for maximum value")
-    onClicked: maxColorDialog.open()
-    background: Rectangle {
-      implicitWidth: 40
-      implicitHeight: 40
-      radius: 5
-      border.color: VisualizePointCloud.maxColor
-      border.width: 2
-      color: VisualizePointCloud.maxColor
+
+    Label {
+      Layout.columnSpan: 1
+      text: "Point cloud"
     }
-    ColorDialog {
-      id: maxColorDialog
-      title: "Choose a color for the maximum value"
-      visible: false
-      onAccepted: {
-        VisualizePointCloud.SetMaxColor(maxColorDialog.color)
-        maxColorDialog.close()
+
+    ComboBox {
+      Layout.columnSpan: 2
+      id: pcCombo
+      Layout.fillWidth: true
+      model: VisualizePointCloud.pointCloudTopicList
+      currentIndex: 0
+      onCurrentIndexChanged: {
+        if (currentIndex < 0)
+          return;
+        VisualizePointCloud.OnPointCloudTopic(textAt(currentIndex));
       }
-      onRejected: {
-        maxColorDialog.close()
+      ToolTip.visible: hovered
+      ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+      ToolTip.text: qsTr("Ignition transport topics publishing PointCloudPacked messages")
+    }
+
+    Label {
+      Layout.columnSpan: 1
+      text: "Float vector"
+    }
+
+    ComboBox {
+      Layout.columnSpan: 2
+      id: floatCombo
+      Layout.fillWidth: true
+      model: VisualizePointCloud.floatVTopicList
+      currentIndex: 0
+      onCurrentIndexChanged: {
+        if (currentIndex < 0)
+          return;
+        VisualizePointCloud.OnFloatVTopic(textAt(currentIndex));
       }
+      ToolTip.visible: hovered
+      ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+      ToolTip.text: qsTr("Ignition transport topics publishing FloatV messages")
     }
   }
 
-  Label {
-    Layout.columnSpan: 1
-    Layout.maximumWidth: 50
-    text: VisualizePointCloud.maxFloatV.toFixed(2)
-    elide: Text.ElideRight
-  }
+  RowLayout {
+    spacing: 10
+    Layout.fillWidth: true
 
-  Label {
-    Layout.columnSpan: 1
-    text: "Max"
+    Label {
+      Layout.columnSpan: 1
+      text: "Min"
+    }
+
+    Label {
+      Layout.columnSpan: 1
+      Layout.maximumWidth: 50
+      text: VisualizePointCloud.minFloatV.toFixed(2)
+      elide: Text.ElideRight
+    }
+
+    Button {
+      Layout.columnSpan: 1
+      id: minColorButton
+      Layout.fillWidth: true
+      ToolTip.visible: hovered
+      ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+      ToolTip.text: qsTr("Color for minimum value")
+      onClicked: minColorDialog.open()
+      background: Rectangle {
+        implicitWidth: 40
+        implicitHeight: 40
+        radius: 5
+        border.color: VisualizePointCloud.minColor
+        border.width: 2
+        color: VisualizePointCloud.minColor
+      }
+      ColorDialog {
+        id: minColorDialog
+        title: "Choose a color for the minimum value"
+        visible: false
+        onAccepted: {
+          VisualizePointCloud.SetMinColor(minColorDialog.color)
+          minColorDialog.close()
+        }
+        onRejected: {
+          minColorDialog.close()
+        }
+      }
+    }
+
+    Button {
+      Layout.columnSpan: 1
+      id: maxColorButton
+      Layout.fillWidth: true
+      ToolTip.visible: hovered
+      ToolTip.delay: Qt.styleHints.mousePressAndHoldInterval
+      ToolTip.text: qsTr("Color for maximum value")
+      onClicked: maxColorDialog.open()
+      background: Rectangle {
+        implicitWidth: 40
+        implicitHeight: 40
+        radius: 5
+        border.color: VisualizePointCloud.maxColor
+        border.width: 2
+        color: VisualizePointCloud.maxColor
+      }
+      ColorDialog {
+        id: maxColorDialog
+        title: "Choose a color for the maximum value"
+        visible: false
+        onAccepted: {
+          VisualizePointCloud.SetMaxColor(maxColorDialog.color)
+          maxColorDialog.close()
+        }
+        onRejected: {
+          maxColorDialog.close()
+        }
+      }
+    }
+
+    Label {
+      Layout.columnSpan: 1
+      Layout.maximumWidth: 50
+      text: VisualizePointCloud.maxFloatV.toFixed(2)
+      elide: Text.ElideRight
+    }
+
+    Label {
+      Layout.columnSpan: 1
+      text: "Max"
+    }
   }
 
   Item {


### PR DESCRIPTION
In the interest of eventually upstreaming the visualization plugin to `ign-gazebo` (i.e. https://github.com/ignitionrobotics/ign-gazebo/issues/1156), I'm making some suggestions to keep the plugin generic. This also means it will automatically scale to other science data sensors that we add in the future.

![viz_pc](https://user-images.githubusercontent.com/5751272/142510214-0fc8cd90-aea7-4e6e-957e-44344191e0ac.gif)

* Instead of hardcoding all `FloatV` topics, populate the dropdown with all topics publishing that message type
* Take min / max value from the current float data (this may be inefficient, and potentially change the color for the same sample with each new message)
* Made the colors configurable from the GUI

These are just some initial improvements to make sure we're not locking the plugin into a single use case. There are many more usability and functionality fixes that we need to make before actually upstreaming this.