### PR TITLE
Remove pre-release repos, Fortress is stable

### DIFF
--- a/docker/debug_integration/Dockerfile
+++ b/docker/debug_integration/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update \
 
 # Add Ignition's latest packages, which may be more up-to-date than the ones from the MBARI image
 RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list' && \
     /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -'
 
 # Install the latest Ignition binaries

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -41,7 +41,6 @@ RUN apt-get update \
 
 # Add Ignition's latest packages, which may be more up-to-date than the ones from the MBARI image
 RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list' && \
-    /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-prerelease `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-prerelease.list' && \
     /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -'
 
 # Install the latest Ignition binaries


### PR DESCRIPTION
No need for the pre-release repo anymore. This shouldn't really be changing anything at this point, but it's safer.

Once we go to Garden (#54 ), we should add the nightly repo.