### PR TITLE
Don't publish LRAUV state while paused

### DIFF
--- a/lrauv_ignition_plugins/src/TethysCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.cc
@@ -484,8 +484,8 @@ void TethysCommPlugin::PostUpdate(
   const ignition::gazebo::UpdateInfo &_info,
   const ignition::gazebo::EntityComponentManager &_ecm)
 {
-  ignition::gazebo::Link baseLink(this->modelLink);
-  auto modelPose = ignition::gazebo::worldPose(this->modelLink, _ecm);
+  if (_info.paused)
+    return;
 
   // Publish state
   lrauv_ignition_plugins::msgs::LRAUVState stateMsg;
@@ -543,6 +543,7 @@ void TethysCommPlugin::PostUpdate(
   stateMsg.set_buoyancyposition_(this->buoyancyBladderVolume);
 
   // Depth
+  auto modelPose = ignition::gazebo::worldPose(this->modelLink, _ecm);
   stateMsg.set_depth_(-modelPose.Pos().Z());
 
   // Roll, pitch, heading


### PR DESCRIPTION
`TethysComm` has been publishing the latest state even while simulation is paused. 

Not publishing while paused helps with debugging, because if we're echoing messages or checking console logs, we can step through them and analyze the latest data slowly. This may also help the controller, I'm not sure what it's doing with all these repeated messages that it is receiving.

One downside of this is that some sensor data may be received between the last publish and the pause, and it won't be published until unpause. But I'm not sure this causes any actual issues.

---

I also went ahead and deleted an unused variable, and moved another one down closer to where it is used.

