### PR TITLE
Remove unused include to solve potential build inconsistencies.

### DIFF
--- a/lrauv_ignition_plugins/src/WorldCommPlugin.hh
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.hh
@@ -30,7 +30,6 @@
 #include <ignition/math/Temperature.hh>
 #include <ignition/transport/Node.hh>
 
-#include "lrauv_command.pb.h"
 #include "lrauv_init.pb.h"
 
 namespace tethys


### PR DESCRIPTION
`WorldCommPlugin.hh` includes an `lrauv_command.pb.h` but doesn't use it:
https://github.com/osrf/lrauv/blob/d6c305f331f87d5994086dc3087c020cd71ebaf7/lrauv_ignition_plugins/src/WorldCommPlugin.hh#L33

Furthermore, the CMake file does not declare any dependency on `lrauv_command.pb.h`:
https://github.com/osrf/lrauv/blob/d6c305f331f87d5994086dc3087c020cd71ebaf7/lrauv_ignition_plugins/CMakeLists.txt#L165

In rare scenarios this can lead to builds which fail. Since I cannot see any instances where `lrauv_command.pb.h` is used  by `WorldCommPlugin.hh` or `WorldCommPlugin.cc` I am removing it.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>