### PR TITLE
Cleanup old science values and improve initial subscription

### DIFF
--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -53,10 +53,25 @@ class tethys::ScienceSensorsSystemPrivate
   /// \brief Publish the latest point cloud
   public: void PublishData();
 
-  /// \brief Service callback for a point cloud with the latest science data.
+  /// \brief Service callback for a point cloud with the latest position data.
   /// \param[in] _res Point cloud to return
   /// \return True
-  public: bool ScienceDataService(ignition::msgs::PointCloudPacked &_res);
+  public: bool PointCloudService(ignition::msgs::PointCloudPacked &_res);
+
+  /// \brief Service callback for a float vector with the latest temperature data.
+  /// \param[in] _res Float vector to return
+  /// \return True
+  public: bool TemperatureService(ignition::msgs::Float_V &_res);
+
+  /// \brief Service callback for a float vector with the latest chlorophyll data.
+  /// \param[in] _res Float vector to return
+  /// \return True
+  public: bool ChlorophyllService(ignition::msgs::Float_V &_res);
+
+  /// \brief Service callback for a float vector with the latest salinity data.
+  /// \param[in] _res Float vector to return
+  /// \return True
+  public: bool SalinityService(ignition::msgs::Float_V &_res);
 
   /// \brief Returns a point cloud message populated with the latest sensor data
   public: ignition::msgs::PointCloudPacked PointCloudMsg();
@@ -196,9 +211,9 @@ class tethys::ScienceSensorsSystemPrivate
   // For 2003080103_mb_l3_las_1x1km.csv
   //public: const float MINIATURE_SCALE = 0.01;
   // For 2003080103_mb_l3_las.csv
-  public: const float MINIATURE_SCALE = 0.0001;
+  //public: const float MINIATURE_SCALE = 0.0001;
   // For simple_test.csv
-  //public: const float MINIATURE_SCALE = 1.0;
+  public: const float MINIATURE_SCALE = 1.0;
 
   // TODO This is a workaround pending upstream Marker performance improvements.
   // \brief Performance trick. Skip depths below this z, so have memory to
@@ -522,10 +537,13 @@ void ScienceSensorsSystemPrivate::GenerateOctrees()
 void ScienceSensorsSystemPrivate::PublishData()
 {
   IGN_PROFILE("ScienceSensorsSystemPrivate::PublishData");
-  this->cloudPub.Publish(this->PointCloudMsg());
   this->tempPub.Publish(this->tempMsg);
   this->chlorPub.Publish(this->chlorMsg);
   this->salPub.Publish(this->salMsg);
+
+  // Publish cloud last. The floatVs are optional, so if the GUI gets the cloud
+  // first it will display a monochrome cloud until it received the floats
+  this->cloudPub.Publish(this->PointCloudMsg());
 }
 
 /////////////////////////////////////////////////
@@ -604,19 +622,31 @@ void ScienceSensorsSystem::Configure(
            << std::endl;
   }
 
+  // Advertise cloud as a service for requests on-demand, and a topic for updates
   this->dataPtr->cloudPub = this->dataPtr->node.Advertise<
       ignition::msgs::PointCloudPacked>(this->dataPtr->cloudTopic);
 
   this->dataPtr->node.Advertise(this->dataPtr->cloudTopic,
-      &ScienceSensorsSystemPrivate::ScienceDataService, this->dataPtr.get());
+      &ScienceSensorsSystemPrivate::PointCloudService, this->dataPtr.get());
 
-  // Advertise science data topics
+  // Advertise science data, also as service and topics
+  std::string temperatureTopic{"/temperature"};
   this->dataPtr->tempPub = this->dataPtr->node.Advertise<
-      ignition::msgs::Float_V>("/temperature");
+      ignition::msgs::Float_V>(temperatureTopic);
+  this->dataPtr->node.Advertise(temperatureTopic,
+      &ScienceSensorsSystemPrivate::TemperatureService, this->dataPtr.get());
+
+  std::string chlorophyllTopic{"/chloropyll"};
   this->dataPtr->chlorPub = this->dataPtr->node.Advertise<
-      ignition::msgs::Float_V>("/chlorophyll");
+      ignition::msgs::Float_V>(chlorophyllTopic);
+  this->dataPtr->node.Advertise(chlorophyllTopic,
+      &ScienceSensorsSystemPrivate::ChlorophyllService, this->dataPtr.get());
+
+  std::string salinityTopic{"/salinity"};
   this->dataPtr->salPub = this->dataPtr->node.Advertise<
-      ignition::msgs::Float_V>("/salinity");
+      ignition::msgs::Float_V>(salinityTopic);
+  this->dataPtr->node.Advertise(salinityTopic,
+      &ScienceSensorsSystemPrivate::SalinityService, this->dataPtr.get());
 }
 
 /////////////////////////////////////////////////
@@ -830,10 +860,34 @@ void ScienceSensorsSystem::RemoveSensorEntities(
 }
 
 //////////////////////////////////////////////////
-bool ScienceSensorsSystemPrivate::ScienceDataService(
+bool ScienceSensorsSystemPrivate::PointCloudService(
     ignition::msgs::PointCloudPacked &_res)
 {
   _res = this->PointCloudMsg();
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool ScienceSensorsSystemPrivate::TemperatureService(
+    ignition::msgs::Float_V &_res)
+{
+  _res = this->tempMsg;
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool ScienceSensorsSystemPrivate::ChlorophyllService(
+    ignition::msgs::Float_V &_res)
+{
+  _res = this->chlorMsg;
+  return true;
+}
+
+//////////////////////////////////////////////////
+bool ScienceSensorsSystemPrivate::SalinityService(
+    ignition::msgs::Float_V &_res)
+{
+  _res = this->salMsg;
   return true;
 }
 

--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -211,9 +211,9 @@ class tethys::ScienceSensorsSystemPrivate
   // For 2003080103_mb_l3_las_1x1km.csv
   //public: const float MINIATURE_SCALE = 0.01;
   // For 2003080103_mb_l3_las.csv
-  //public: const float MINIATURE_SCALE = 0.0001;
+  public: const float MINIATURE_SCALE = 0.0001;
   // For simple_test.csv
-  public: const float MINIATURE_SCALE = 1.0;
+  //public: const float MINIATURE_SCALE = 1.0;
 
   // TODO This is a workaround pending upstream Marker performance improvements.
   // \brief Performance trick. Skip depths below this z, so have memory to
@@ -542,7 +542,7 @@ void ScienceSensorsSystemPrivate::PublishData()
   this->salPub.Publish(this->salMsg);
 
   // Publish cloud last. The floatVs are optional, so if the GUI gets the cloud
-  // first it will display a monochrome cloud until it received the floats
+  // first it will display a monochrome cloud until it receives the floats
   this->cloudPub.Publish(this->PointCloudMsg());
 }
 

--- a/lrauv_ignition_plugins/src/VisualizePointCloud.hh
+++ b/lrauv_ignition_plugins/src/VisualizePointCloud.hh
@@ -35,6 +35,10 @@ namespace tethys
   class VisualizePointCloudPrivate;
 
   /// \brief Visualize PointCloudPacked messages in the 3D scene.
+  /// By default, the whole cloud is displayed using a single color. Users
+  /// can optionally choose a topic publishing FloatV messages which will be
+  /// used to color all points with a color gradient according to their values.
+  /// NaN values on the FloatV message aren't displayed.
   class VisualizePointCloud : public ignition::gui::Plugin
   {
     Q_OBJECT

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -63,14 +63,16 @@
       <world_frame_orientation>ENU</world_frame_orientation>
 
       <!-- For 2003080103_mb_l3_las.csv -->
+      <latitude_deg>35.5999984741211</latitude_deg>
+      <longitude_deg>-121.779998779297</longitude_deg>
 
       <!-- For 2003080103_mb_l3_las_1x1km.csv -->
       <!--latitude_deg>36.8024781413352</latitude_deg>
       <longitude_deg>-121.829647676843</longitude_deg-->
 
       <!-- For simple_test.csv -->
-      <latitude_deg>0</latitude_deg>
-      <longitude_deg>0</longitude_deg>
+      <!--latitude_deg>0</latitude_deg>
+      <longitude_deg>0</longitude_deg-->
 
       <elevation>0</elevation>
       <heading_deg>0</heading_deg>
@@ -78,8 +80,9 @@
     <plugin
       filename="ScienceSensorsSystem"
       name="tethys::ScienceSensorsSystem">
+      <data_path>2003080103_mb_l3_las.csv</data_path>
       <!--data_path>2003080103_mb_l3_las_1x1km.csv</data_path-->
-      <data_path>simple_test.csv</data_path>
+      <!--data_path>simple_test.csv</data_path-->
     </plugin>
 
     <gui fullscreen="0">

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -63,16 +63,14 @@
       <world_frame_orientation>ENU</world_frame_orientation>
 
       <!-- For 2003080103_mb_l3_las.csv -->
-      <latitude_deg>35.5999984741211</latitude_deg>
-      <longitude_deg>-121.779998779297</longitude_deg>
 
       <!-- For 2003080103_mb_l3_las_1x1km.csv -->
       <!--latitude_deg>36.8024781413352</latitude_deg>
       <longitude_deg>-121.829647676843</longitude_deg-->
 
       <!-- For simple_test.csv -->
-      <!--latitude_deg>0</latitude_deg>
-      <longitude_deg>0</longitude_deg-->
+      <latitude_deg>0</latitude_deg>
+      <longitude_deg>0</longitude_deg>
 
       <elevation>0</elevation>
       <heading_deg>0</heading_deg>
@@ -80,9 +78,8 @@
     <plugin
       filename="ScienceSensorsSystem"
       name="tethys::ScienceSensorsSystem">
-      <data_path>2003080103_mb_l3_las.csv</data_path>
       <!--data_path>2003080103_mb_l3_las_1x1km.csv</data_path-->
-      <!--data_path>simple_test.csv</data_path-->
+      <data_path>simple_test.csv</data_path>
     </plugin>
 
     <gui fullscreen="0">
@@ -162,6 +159,7 @@
           <property key="state" type="string">floating</property>
           <property key="showTitleBar" type="bool">false</property>
         </ignition-gui>
+        <warn_on_action_failure>false</warn_on_action_failure>
       </plugin>
       <plugin filename="SelectEntities" name="Select Entities">
         <ignition-gui>


### PR DESCRIPTION
This addresses this comment by @mabelzhang : https://github.com/osrf/lrauv/pull/93#issuecomment-985776670

* Needs this to reduce warnings, but not for functionality: https://github.com/ignitionrobotics/ign-gui/pull/326

![switch_science](https://user-images.githubusercontent.com/5751272/144697688-e33c3e18-71ba-47c8-b172-c260975c7b9c.gif)

---

* Added services for all `FloatV`s, which were missing. This is needed to get the data on demand, since Ignition Transport doesn't support latching.
* Make the `FloatV` optional. This is not a use case here, but I think it's a nice-to-have when we upstream.
* Instead of skipping NaNs when displaying, send a `DELETE_MARKER` command, so that if the data changes from valid to `NaN` it disappears.
* Removed the `-` from the marker namespaces because it looked awkward when there's no float topic