### PR TITLE
Update density value in tethys comm plugin.

### DIFF
--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -153,6 +153,7 @@
         <command_topic>tethys/command_topic</command_topic>
         <state_topic>tethys/state_topic</state_topic>
         <debug_printout>0</debug_printout>
+        <ocean_density>1000</ocean_density>
       </plugin>
       <plugin
         filename="HydrodynamicsPlugin"

--- a/lrauv_ignition_plugins/proto/lrauv_state.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_state.proto
@@ -93,6 +93,6 @@ message LRAUVState
   float soundSpeed_               = 28;
   float temperature_              = 29;  // Celsius
   float salinity_                 = 30;  // PSU
-  float density_                  = 31;
+  float density_                  = 31;  // Density of the surrounding water in Kg / m ^ 3
   repeated float values_          = 32;  // Size 4 (0: chlorophyll in ug / L, 1: pressure in Pa)
 }

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.cc
@@ -202,6 +202,10 @@ void TethysCommPlugin::Configure(
   {
     this->debugPrintout = _sdf->Get<bool>("debug_printout");
   }
+  if (_sdf->HasElement("density"))
+  {
+    this->oceanDensity = _sdf->Get<double>("ocean_density");
+  }
 
   // Initialize transport
   if (!this->node.Subscribe(this->commandTopic,
@@ -592,6 +596,9 @@ void TethysCommPlugin::PostUpdate(
   stateMsg.set_salinity_(this->latestSalinity);
   stateMsg.set_temperature_(this->latestTemperature.Celsius());
   stateMsg.add_values_(this->latestChlorophyll);
+
+  // Set Ocean Density
+  stateMsg.set_density_(this->oceanDensity);
 
   double pressure = 0.0;
   if (latlon)

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.hh
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.hh
@@ -182,6 +182,9 @@ namespace tethys
     /// Latest chlorophyll data received from sensor. NaN if not received.
     private: float latestChlorophyll{std::nanf("")};
 
+    /// Ocean Density
+    private: double oceanDensity{1000};
+
     /// Latest current data received from sensor. NaN if not received.
     private: ignition::math::Vector3d latestCurrent
         {std::nan(""), std::nan(""), std::nan("")};

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.hh
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.hh
@@ -182,7 +182,7 @@ namespace tethys
     /// Latest chlorophyll data received from sensor. NaN if not received.
     private: float latestChlorophyll{std::nanf("")};
 
-    /// Ocean Density
+    /// Ocean Density in kg / m ^ 3
     private: double oceanDensity{1000};
 
     /// Latest current data received from sensor. NaN if not received.


### PR DESCRIPTION
The density value is used by the vertical controller in the LRAUV's controller. Because we have not been populating this field with a non-zero value, the Vertical Controller would crash. For more robustness, the controller itself should start of with a default density value. 1000kgm^3 could be a good value.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>