### PR TITLE
Log LRAUV application errors as errors.

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -213,6 +213,14 @@ class LrauvTestFixture : public ::testing::Test
         // FIXME: LRAUV app hangs after quit, so force close it
         // See https://github.com/osrf/lrauv/issues/83
         std::string bufferStr{buffer};
+
+        std::string error{"ERROR"};
+        if (auto found = bufferStr.find(quit) != std::string::npos)
+        {
+          ignerr << "LRAUV Application reported error:" << std::endl
+            << buffer << "\n";
+        }
+
         std::string quit{">quit\n"};
         if (auto found = bufferStr.find(quit) != std::string::npos)
         {

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -203,10 +203,10 @@ class LrauvTestFixture : public ::testing::Test
       return;
     }
 
-    char buffer[128];
+    char buffer[512];
     while (!feof(pipe))
     {
-      if (fgets(buffer, 128, pipe) != nullptr)
+      if (fgets(buffer, 512, pipe) != nullptr)
       {
         igndbg << "CMD OUTPUT: " << buffer << std::endl;
 
@@ -215,7 +215,7 @@ class LrauvTestFixture : public ::testing::Test
         std::string bufferStr{buffer};
 
         std::string error{"ERROR"};
-        if (auto found = bufferStr.find(quit) != std::string::npos)
+        if (auto found = bufferStr.find(error) != std::string::npos)
         {
           ignerr << "LRAUV Application reported error:" << std::endl
             << buffer << "\n";


### PR DESCRIPTION
In many cases we find "flaky" mission integration tests. Often this is because of components crashing on the LRAUV controller side. This often leads us down a very painful debugging journey. This patch proposes the following change: if there is an error reported by the LRAUV application, report it. The hope is that this will save us valuable time when debugging.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>