### PR TITLE
Temporary work around to ensure pathfinder is disabled

### DIFF
--- a/docker/debug_integration/Dockerfile
+++ b/docker/debug_integration/Dockerfile
@@ -70,6 +70,9 @@ COPY . src/lrauv
 # Build image
 RUN [ "/bin/bash" , "-c" , "colcon build --cmake-args='-DBUILD_TESTING=true'" ]
 
+RUN [ "/bin/bash" , "-c" , "sed -i '48s/1/0/' ~/lrauv_ws/src/lrauv-application/Config/sim/Sensor.cfg"]
+RUN [ "/bin/bash" , "-c" , "sed -i '49s/1/0/' ~/lrauv_ws/src/lrauv-application/Config/sim/Sensor.cfg"]
+
 # Run tests
 # RUN [ "/bin/bash" , "-c" , ". ~/lrauv_ws/install/setup.sh; colcon test --event-handlers console_direct+" ]
 # RUN [ "/bin/bash" , "-c" , ". ~/lrauv_ws/install/setup.sh; colcon test-result" ]"

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -69,6 +69,8 @@ COPY . src/lrauv
 
 # Build image
 RUN [ "/bin/bash" , "-c" , "colcon build --cmake-args='-DBUILD_TESTING=true'" ]
+RUN [ "/bin/bash" , "-c" , "sed -i '48s/1/0/' ~/lrauv_ws/src/lrauv-application/Config/sim/Sensor.cfg"]
+RUN [ "/bin/bash" , "-c" , "sed -i '49s/1/0/' ~/lrauv_ws/src/lrauv-application/Config/sim/Sensor.cfg"]
 
 # Run tests
 RUN [ "/bin/bash" , "-c" , ". ~/lrauv_ws/install/setup.sh; colcon test --event-handlers console_direct+" ]


### PR DESCRIPTION
This adds a config to disable the RDI Pathfinder component which keeps causing our tests to timeout. Since we are not simulating this component I don't see why it should be enabled in our CI and tests.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>