### PR TITLE
Allow for time taken for YoYo to start

### DIFF
--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -90,8 +90,13 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     // Speed is about 1 m / s
     auto dist = (pose.Pos() - prevPose.Pos()).Length();
 
+    // Check velocity is positive
     auto linVel = dist / time100it;
-    EXPECT_LT(0.0, linVel);
+    if (i > 2000)
+    {
+      // Check that the vehicle actually is moving.
+      EXPECT_LT(0.0, linVel);
+    }
 
     EXPECT_NEAR(1.0, linVel, 1.0) << i;
 


### PR DESCRIPTION
Occassionally it may take time for the yoyo mission to get started. Hence, the system may have a velocity of zero for the first few iterations. This PR starts the velocity check after few iterations.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>