### PR TITLE
Also report critical errors on tests

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -215,14 +215,15 @@ class LrauvTestFixture : public ::testing::Test
         std::string bufferStr{buffer};
 
         std::string error{"ERROR"};
-        if (auto found = bufferStr.find(error) != std::string::npos)
+        std::string critical{"CRITICAL"};
+        if (bufferStr.find(error) != std::string::npos ||
+            bufferStr.find(critical) != std::string::npos)
         {
-          ignerr << "LRAUV Application reported error:" << std::endl
-            << buffer << "\n";
+          ignerr << buffer << "\n";
         }
 
         std::string quit{">quit\n"};
-        if (auto found = bufferStr.find(quit) != std::string::npos)
+        if (bufferStr.find(quit) != std::string::npos)
         {
           ignmsg << "Quitting application" << std::endl;
           break;


### PR DESCRIPTION
* Follow up to https://github.com/osrf/lrauv/pull/114
* See comment https://github.com/osrf/lrauv/pull/114#discussion_r770811257

I left the errors there because there haven't been too many of them and they may provide useful context.

I also removed the `LRAUV Application reported error` because I think it was adding too much extra text to the logs.
