### PR TITLE
Update quit string on tests

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -222,7 +222,7 @@ class LrauvTestFixture : public ::testing::Test
           ignerr << buffer << "\n";
         }
 
-        std::string quit{">quit\n"};
+        std::string quit{"Stop Mission called by Supervisor::terminate\n"};
         if (bufferStr.find(quit) != std::string::npos)
         {
           ignmsg << "Quitting application" << std::endl;


### PR DESCRIPTION
That has changed on the new Docker images.

A separate "issue" is that the missions now don't terminate on critical failures, so they're running until the timeout - which causes CI to take longer and test expectations to fail (we get more drift, etc).