### PR TITLE
Mission tests: kill LRAUV application after enough iterations

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -204,33 +204,44 @@ class LrauvTestFixture : public ::testing::Test
     }
 
     char buffer[512];
-    while (!feof(pipe))
+    while (fgets(buffer, 512, pipe) != nullptr)
     {
-      if (fgets(buffer, 512, pipe) != nullptr)
+      igndbg << "CMD OUTPUT: " << buffer << std::endl;
+
+      // FIXME: LRAUV app hangs after quit, so force close it
+      // See https://github.com/osrf/lrauv/issues/83
+      std::string bufferStr{buffer};
+
+      std::string error{"ERROR"};
+      std::string critical{"CRITICAL"};
+      if (bufferStr.find(error) != std::string::npos ||
+          bufferStr.find(critical) != std::string::npos)
       {
-        igndbg << "CMD OUTPUT: " << buffer << std::endl;
+        ignerr << buffer << "\n";
+      }
 
-        // FIXME: LRAUV app hangs after quit, so force close it
-        // See https://github.com/osrf/lrauv/issues/83
-        std::string bufferStr{buffer};
-
-        std::string error{"ERROR"};
-        std::string critical{"CRITICAL"};
-        if (bufferStr.find(error) != std::string::npos ||
-            bufferStr.find(critical) != std::string::npos)
-        {
-          ignerr << buffer << "\n";
-        }
-
-        std::string quit{"Stop Mission called by Supervisor::terminate\n"};
-        if (bufferStr.find(quit) != std::string::npos)
-        {
-          ignmsg << "Quitting application" << std::endl;
-          break;
-        }
+      std::string quit{"Stop Mission called by Supervisor::terminate\n"};
+      if (bufferStr.find(quit) != std::string::npos)
+      {
+        ignmsg << "Quitting application" << std::endl;
+        break;
       }
     }
 
+    KillLRAUV();
+
+    pclose(pipe);
+
+    ignmsg << "Completed command [" << cmd << "]" << std::endl;
+
+    _running = false;
+  }
+
+  /// \brief Kill all LRAUV processes.
+  /// \return True if some process was killed.
+  public: static bool KillLRAUV()
+  {
+    bool killed{false};
     for (auto process : {"sh.*bin/LRAUV", "bin/LRAUV"})
     {
       auto pid = GetPID(process);
@@ -243,13 +254,9 @@ class LrauvTestFixture : public ::testing::Test
 
       ignmsg << "Killing process [" << process << "] with pid [" << pid << "]" << std::endl;
       kill(pid, 9);
+      killed = true;
     }
-
-    pclose(pipe);
-
-    ignmsg << "Completed command [" << cmd << "]" << std::endl;
-
-    _running = false;
+    return killed;
   }
 
   /// \brief How many times has OnPostUpdate been run

--- a/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
@@ -53,16 +53,18 @@ TEST_F(LrauvTestFixture, DepthVBS)
         lrauvRunning);
   });
 
-  int maxIterations{28000};
+  // Run enough iterations (chosen empirically) to reach steady state, then kill
+  // the controller
+  int targetIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < targetIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  ASSERT_LT(maxIterations, this->tethysPoses.size());
+  ASSERT_LT(targetIterations, this->tethysPoses.size());
 
   LrauvTestFixture::KillLRAUV();
   lrauvThread.join();
@@ -70,7 +72,7 @@ TEST_F(LrauvTestFixture, DepthVBS)
   ignmsg << "Logged [" << this->tethysPoses.size() << "] poses" << std::endl;
 
   // Uncomment to get new expectations
-  // for (int i = 2000; i <= maxIterations; i += 2000)
+  // for (int i = 2000; i <= targetIterations; i += 2000)
   // {
   //   auto pose = this->tethysPoses[i];
   //   std::cout << "this->CheckRange(" << i << ", {"

--- a/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
@@ -53,22 +53,21 @@ TEST_F(LrauvTestFixture, DepthVBS)
         lrauvRunning);
   });
 
+  int maxIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_FALSE(lrauvRunning);
+  ASSERT_LT(maxIterations, this->tethysPoses.size());
 
+  LrauvTestFixture::KillLRAUV();
   lrauvThread.join();
 
   ignmsg << "Logged [" << this->tethysPoses.size() << "] poses" << std::endl;
-
-  int maxIterations{28000};
-  ASSERT_LT(maxIterations, this->tethysPoses.size());
 
   // Uncomment to get new expectations
   // for (int i = 2000; i <= maxIterations; i += 2000)

--- a/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
@@ -53,16 +53,18 @@ TEST_F(LrauvTestFixture, PitchDepthVBS)
         lrauvRunning);
   });
 
-  int maxIterations{28000};
+  // Run enough iterations (chosen empirically) to reach steady state, then kill
+  // the controller
+  int targetIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < targetIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_LT(maxIterations, this->tethysPoses.size());
+  EXPECT_LT(targetIterations, this->tethysPoses.size());
 
   LrauvTestFixture::KillLRAUV();
   lrauvThread.join();

--- a/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
@@ -53,22 +53,21 @@ TEST_F(LrauvTestFixture, PitchDepthVBS)
         lrauvRunning);
   });
 
+  int maxIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_FALSE(lrauvRunning);
+  EXPECT_LT(maxIterations, this->tethysPoses.size());
 
+  LrauvTestFixture::KillLRAUV();
   lrauvThread.join();
 
   ignmsg << "Logged [" << this->tethysPoses.size() << "] poses" << std::endl;
-
-  int maxIterations{28000};
-  ASSERT_LT(maxIterations, this->tethysPoses.size());
 
   bool targetReached = false, firstSample = true;
   double prev_z = 0, totalDepthChange = 0;

--- a/lrauv_ignition_plugins/test/test_mission_pitch_mass.cc
+++ b/lrauv_ignition_plugins/test/test_mission_pitch_mass.cc
@@ -58,22 +58,21 @@ TEST_F(LrauvTestFixture, PitchMass)
         lrauvRunning);
   });
 
+  int maxIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_FALSE(lrauvRunning);
+  EXPECT_LT(maxIterations, this->tethysPoses.size());
 
+  LrauvTestFixture::KillLRAUV();
   lrauvThread.join();
 
   ignmsg << "Logged [" << this->tethysPoses.size() << "] poses" << std::endl;
-
-  int maxIterations{28000};
-  EXPECT_LT(maxIterations, this->tethysPoses.size());
 
   // Give it some iterations to reach steady state
   for (auto i = 2000u; i < this->tethysPoses.size(); i = i + 1000)

--- a/lrauv_ignition_plugins/test/test_mission_pitch_mass.cc
+++ b/lrauv_ignition_plugins/test/test_mission_pitch_mass.cc
@@ -58,16 +58,18 @@ TEST_F(LrauvTestFixture, PitchMass)
         lrauvRunning);
   });
 
-  int maxIterations{28000};
+  // Run enough iterations (chosen empirically) to reach steady state, then kill
+  // the controller
+  int targetIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < targetIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_LT(maxIterations, this->tethysPoses.size());
+  EXPECT_LT(targetIterations, this->tethysPoses.size());
 
   LrauvTestFixture::KillLRAUV();
   lrauvThread.join();

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -61,16 +61,18 @@ TEST_F(LrauvTestFixture, YoYoCircle)
         lrauvRunning);
   });
 
-  int maxIterations{28000};
+  // Run enough iterations (chosen empirically) to reach steady state, then kill
+  // the controller
+  int targetIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < targetIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_LT(maxIterations, this->tethysPoses.size());
+  EXPECT_LT(targetIterations, this->tethysPoses.size());
 
   LrauvTestFixture::KillLRAUV();
   lrauvThread.join();

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -61,22 +61,21 @@ TEST_F(LrauvTestFixture, YoYoCircle)
         lrauvRunning);
   });
 
+  int maxIterations{28000};
   int maxSleep{100};
   int sleep{0};
-  for (; sleep < maxSleep && lrauvRunning; ++sleep)
+  for (; sleep < maxSleep && lrauvRunning && this->iterations < maxIterations; ++sleep)
   {
     igndbg << "Ran [" << this->iterations << "] iterations." << std::endl;
     std::this_thread::sleep_for(1s);
   }
   EXPECT_LT(sleep, maxSleep);
-  EXPECT_FALSE(lrauvRunning);
+  EXPECT_LT(maxIterations, this->tethysPoses.size());
 
+  LrauvTestFixture::KillLRAUV();
   lrauvThread.join();
 
   ignmsg << "Logged [" << this->tethysPoses.size() << "] poses" << std::endl;
-
-  int minIterations{28000};
-  ASSERT_LT(minIterations, this->tethysPoses.size());
 
   // Check bounds
   double dtSec = std::chrono::duration<double>(this->dt).count();

--- a/lrauv_ignition_plugins/test/test_state_msg.cc
+++ b/lrauv_ignition_plugins/test/test_state_msg.cc
@@ -28,13 +28,20 @@
 #include "lrauv_state.pb.h"
 
 //////////////////////////////////////////////////
-TEST_F(LrauvTestFixture, Command)
+TEST_F(LrauvTestFixture, State)
 {
   // TODO(chapulina) Test other fields, see
   // https://github.com/osrf/lrauv/pull/81
 
   // Initial state
   this->fixture->Server()->Run(true, 100, false);
+  int maxSleep{100};
+  int sleep{0};
+  for (; sleep < maxSleep && this->stateMsgs.size() < 100; ++sleep)
+  {
+    std::this_thread::sleep_for(100ms);
+  }
+  EXPECT_LT(sleep, maxSleep);
   EXPECT_EQ(100, this->stateMsgs.size());
 
   auto latest = this->stateMsgs.back();


### PR DESCRIPTION
Thanks to @braanan , now the missions don't end up in critical errors anymore. Which means that they run until their timeouts, which are very large (hours).

Our tests had been relying on the missions ending relatively quickly until now, and with the latest fixes, they're running forever (I had to cancel GitHub actions that was running for 1.5 hours on #121).

Instead of updating the mission timeouts and relying on the LRAUV application terminating on its own, the idea on this PR is that the tests should know when they've received enough data and terminate the application then.

We've been killing the application anyway because of #4 , so now we're actually taking advantage of that.

