### PR TITLE
Remove miniature scale from science data and fix segfault

### DIFF
--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -104,9 +104,9 @@ class tethys::ScienceSensorsSystemPrivate
     const std::vector<int> &_inds,
     std::vector<float> &_new);
 
-  /// \brief Sort vector in-place, keeping track of indices
+  /// \brief Sort vector, store indices to original vector after sorting.
+  /// Original vector unchanged.
   /// \param[in] _v Vector to sort
-  /// \param[out] _v Sorted vector
   /// \param[out] _idx Indices of original vector in sorted vector
   public: template<typename T>
   void SortIndices(
@@ -880,7 +880,7 @@ float ScienceSensorsSystemPrivate::BarycentricInterpolate(
     return std::numeric_limits<float>::quiet_NaN();
   }
 
-  // Sort points
+  // Sort points and store the indices
   std::vector<float> xsSorted;
   std::vector<size_t> xsSortedInds;
   for (int i = 0; i < _xs.size(); ++i)
@@ -888,6 +888,11 @@ float ScienceSensorsSystemPrivate::BarycentricInterpolate(
     xsSorted.push_back(_xs(i));
   }
   SortIndices(xsSorted, xsSortedInds);
+  // Access sorted indices to get the new sorted array
+  for (int i = 0; i < xsSortedInds.size(); ++i)
+  {
+    xsSorted[i] = _xs(xsSortedInds[i]);
+  }
 
   int ltPSortedIdx{-1};
   int gtPSortedIdx{-1};
@@ -909,13 +914,23 @@ float ScienceSensorsSystemPrivate::BarycentricInterpolate(
       break;
     }
   }
+
+  // Sanity check
   if (ltPSortedIdx < 0 || ltPSortedIdx >= xsSortedInds.size() ||
       gtPSortedIdx < 0 || gtPSortedIdx >= xsSortedInds.size())
   {
-    ignwarn << "Failed to find consecutive elements in sorted vector. Indices ["
-            << ltPSortedIdx << "] / [" << gtPSortedIdx
-            << "] for vector sized [" << xsSortedInds.size()
-            << "]. Cannot interpolate." << std::endl;
+    ignwarn << "1D linear interpolation: cannot find pair of consecutive "
+      << "neighbors that query point lies between. Cannot interpolate. "
+      << "(This should not happen!)"
+      << std::endl;
+    if (this->DEBUG_INTERPOLATE)
+    {
+      igndbg << "Neighbors: " << std::endl << _xs << std::endl;
+      igndbg << "Sorted neighbors: " << std::endl;
+      for (int i = 0; i < xsSorted.size(); ++i)
+        igndbg << xsSorted[i] << std::endl;
+      igndbg << "Query point: " << std::endl << _p << std::endl;
+    }
     return std::numeric_limits<float>::quiet_NaN();
   }
 
@@ -927,9 +942,13 @@ float ScienceSensorsSystemPrivate::BarycentricInterpolate(
   int ltPIdx = xsSortedInds[ltPSortedIdx];
   int gtPIdx = xsSortedInds[gtPSortedIdx];
 
+  // Sanity check
   if (ltPIdx >= _values.size() || gtPIdx >= _values.size())
   {
-    ignwarn << "Bad indices. Cannot interpolate." << std::endl;
+    ignwarn << "1D linear interpolation: mapping from sorted index to "
+      << "original index resulted in invalid index. Cannot interpolate. "
+      << "(This should not happen!)"
+      << std::endl;
     return std::numeric_limits<float>::quiet_NaN();
   }
   float result = ltPWeight * _values[ltPIdx] + gtPWeight * _values[gtPIdx];

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -101,7 +101,17 @@
         <scene>scene</scene>
         <ambient_light>0.4 0.4 0.4</ambient_light>
         <background_color>0.8 0.8 0.8</background_color>
+        <!-- looking at robot -->
         <camera_pose>0 6 6 0 0.5 -1.57</camera_pose>
+        <!-- looking at all science data for 2003080103_mb_l3_las.csv -->
+        <!--camera_pose>-50000 -30000 250000 0 1.1 1.58</camera_pose-->
+        <camera_clip>
+          <!-- ortho view needs low near clip -->
+          <!-- but a very low near clip messes orbit's far clip ?! -->
+          <near>0.1</near>
+          <!-- See 3000 km away -->
+          <far>3000000</far>
+        </camera_clip>
       </plugin>
 
       <!-- Plugins that add functionality to the scene -->
@@ -260,10 +270,25 @@
           <property type="string" key="state">docked_collapsed</property>
         </ignition-gui>
       </plugin>
+      <plugin filename="ViewAngle" name="Camera controls">
+        <ignition-gui>
+          <title>Camera controls</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+      </plugin>
       <plugin filename="GridConfig" name="Grid config">
         <ignition-gui>
           <property type="string" key="state">docked_collapsed</property>
         </ignition-gui>
+        <insert>
+          <!-- 300 km x 300 km -->
+          <cell_count>6</cell_count>
+          <vertical_cell_count>0</vertical_cell_count>
+          <!-- 50 km -->
+          <cell_length>50000</cell_length>
+          <pose>0 100000 0  0 0 0.32</pose>
+          <color>0 1 0 1</color>
+        </insert>
         <insert>
           <!-- 0.1 km x 0.1 km -->
           <cell_count>100</cell_count>
@@ -303,32 +328,23 @@
       <direction>-0.5 0.1 -0.9</direction>
     </light>
 
-    <!-- Uncomment if you need a ground plane -->
-    <!-- <model name="ground_plane">
+
+    <!-- This invisible plane helps with orbiting the camera, especially at large scales -->
+    <model name="horizontal_plane">
       <static>true</static>
       <link name="link">
-        <collision name="collision">
-          <geometry>
-            <plane>
-              <normal>0 0 1</normal>
-            </plane>
-          </geometry>
-        </collision>
         <visual name="visual">
           <geometry>
             <plane>
               <normal>0 0 1</normal>
-              <size>100 100</size>
+              <!-- 300 km x 300 km -->
+              <size>300000 300000</size>
             </plane>
           </geometry>
-          <material>
-            <ambient>0.8 0.8 0.8 1</ambient>
-            <diffuse>0.8 0.8 0.8 1</diffuse>
-            <specular>0.8 0.8 0.8 1</specular>
-          </material>
+          <transparency>1.0</transparency>
         </visual>
       </link>
-    </model> -->
+    </model>
 
     <!-- Uncomment for particle effect
       Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied


### PR DESCRIPTION
* Broken off #88 

Tests were crashing for that PR, while investigating, I noticed it happened because the `MINIATURE_SCALE` had been removed.

This PR removes the miniature scale and prints a warning instead of segfaulting, but I haven't looked closely into the barycentric interpolation to see why the miniature scale caused the issue, could you take a look @mabelzhang ?

I also added other changes from #88 which help us not need the miniature scale:

* The invisible ground plane makes it possible to easily scroll to a far away distance
* This can be seen with the 300kmx300km grid that is also added here
* The increased camera clipping distances are also needed to see the entire grid from a distance
* Added the camera controls plugin so the user can easily go back to the initial camera angle

![miniature_scale](https://user-images.githubusercontent.com/5751272/147040725-d3d1a21f-b513-433c-b764-ea35bd58b1ee.gif)
