### PR TITLE
Update Garden dependencies

### DIFF
--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -49,7 +49,7 @@ RUN apt-get -qq update && apt-get -q -y install \
   ignition-garden
 
 # Upgrade to make sure we get the latest nightlies
-RUN apt-get upgrade
+RUN apt-get upgrade -y
 
 # Install PCL
 RUN apt-get update \

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -45,8 +45,8 @@ RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable
     /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -'
 
 # Install and upgrade the latest Ignition binaries
-RUN apt-get -qq update && apt-get upgrade -y && apt-get -q -y install \
-  ignition-garden
+RUN apt-get -qq update && apt-get -q -y install \
+  ignition-garden && apt-get upgrade -y
 
 # Install PCL
 RUN apt-get update \

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -48,6 +48,9 @@ RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable
 RUN apt-get -qq update && apt-get -q -y install \
   ignition-garden
 
+# Upgrade to make sure we get the latest nightlies
+RUN apt-get upgrade
+
 # Install PCL
 RUN apt-get update \
  && apt-get install -y \

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -44,12 +44,9 @@ RUN /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable
     /bin/sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-nightly `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-nightly.list' && \
     /bin/sh -c 'wget http://packages.osrfoundation.org/gazebo.key -O - | apt-key add -'
 
-# Install the latest Ignition binaries
-RUN apt-get -qq update && apt-get -q -y install \
+# Install and upgrade the latest Ignition binaries
+RUN apt-get -qq update && apt-get upgrade -y && apt-get -q -y install \
   ignition-garden
-
-# Upgrade to make sure we get the latest nightlies
-RUN apt-get upgrade -y
 
 # Install PCL
 RUN apt-get update \

--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -41,8 +41,8 @@ set(IGN_PLUGIN_VER ${ignition-plugin1_VERSION_MAJOR})
 find_package(ignition-utils1 REQUIRED)
 set(IGN_UTILS_VER ${ignition-utils1_VERSION_MAJOR})
 
-find_package(ignition-common4 REQUIRED COMPONENTS profiler)
-set(IGN_COMMON_VER ${ignition-common4_VERSION_MAJOR})
+find_package(ignition-common5 REQUIRED COMPONENTS profiler)
+set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
 
 find_package (Eigen3 3.3 REQUIRED)
 


### PR DESCRIPTION
Quick update since we have new dependencies on Garden. Note that `ign-math`, `sdf` and `ign-physics` have also been bumped, so be sure to update your local workspaces.