### PR TITLE
 Check yaw rates instead of positions when yoyoing (retargeted #124 to main)

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -98,6 +98,19 @@ class LrauvTestFixture : public ::testing::Test
         tethysLinearVel.push_back(linkVel.value());
 
         this->iterations++;
+
+        ignition::gazebo::Model model(modelEntity);
+        auto linkEntity = model.LinkByName(_ecm, "base_link");
+        EXPECT_NE(ignition::gazebo::kNullEntity, linkEntity);
+
+        ignition::gazebo::Link link(linkEntity);
+        auto linkAngVel = link.WorldAngularVelocity(_ecm);
+        EXPECT_TRUE(linkAngVel.has_value());
+        tethysAngularVel.push_back(linkAngVel.value());
+
+        auto linkVel = link.WorldLinearVelocity(_ecm);
+        EXPECT_TRUE(linkVel.has_value());
+        tethysLinearVel.push_back(linkVel.value());
       });
     fixture->Finalize();
   }
@@ -282,6 +295,9 @@ class LrauvTestFixture : public ::testing::Test
 
   /// \brief All tethys linear velocities in order
   public: std::vector<ignition::math::Vector3d> tethysLinearVel;
+
+  /// \brief All tethys angular velocities in order
+  public: std::vector<ignition::math::Vector3d> tethysAngularVel;
 
   /// \brief All state messages in order
   public: std::vector<lrauv_ignition_plugins::msgs::LRAUVState> stateMsgs;

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -97,20 +97,11 @@ class LrauvTestFixture : public ::testing::Test
         EXPECT_TRUE(linkVel.has_value());
         tethysLinearVel.push_back(linkVel.value());
 
-        this->iterations++;
-
-        ignition::gazebo::Model model(modelEntity);
-        auto linkEntity = model.LinkByName(_ecm, "base_link");
-        EXPECT_NE(ignition::gazebo::kNullEntity, linkEntity);
-
-        ignition::gazebo::Link link(linkEntity);
         auto linkAngVel = link.WorldAngularVelocity(_ecm);
         EXPECT_TRUE(linkAngVel.has_value());
         tethysAngularVel.push_back(linkAngVel.value());
 
-        auto linkVel = link.WorldLinearVelocity(_ecm);
-        EXPECT_TRUE(linkVel.has_value());
-        tethysLinearVel.push_back(linkVel.value());
+        this->iterations++;
       });
     fixture->Finalize();
   }

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -106,7 +106,7 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     EXPECT_LT(-22.7, pose.Pos().Z()) << i;
     if (i > 4000)
     {
-      EXPECT_GT(0.4, pose.Pos().Z()) << i;
+      EXPECT_GT(0.5, pose.Pos().Z()) << i;
     }
 
 
@@ -117,11 +117,20 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     // Trajectory projected onto the horizontal plane is roughly a circle
     ignition::math::Vector2d planarPos{pose.Pos().X(), pose.Pos().Y()};
 
-    //ignition::math::Vector2d center{-4.0, -23.0};
-    //planarPos -= center;
+    if (i > 6000)
+    {
+      // Once the vehicle achieves its full velocity the vehicle should have a
+      // nominal yaw rate of around 0.37-0.38rad/s. This means that the vehicle
+      // should keep spinning in a circle.
+      EXPECT_NEAR(tethysAngularVel[i].Z(), 0.037, 2e-2)
+        << i << " yaw rate: " << tethysAngularVel[i].Z();
 
-    //double meanRadius{20.0};
-    //EXPECT_NEAR(20.0, planarPos.Length(), 4.0) << i << ", " << planarPos;
+      // At the same time the roll rate should be near zero
+      EXPECT_NEAR(tethysAngularVel[i].Y(), 0, 1e-1) << i;
+
+      // And the linear velocity should be near 1m/s
+      EXPECT_NEAR(tethysLinearVel[i].Length(), 1.0, 2e-1) << i;
+    }
   }
 }
 

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -113,7 +113,7 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     EXPECT_LT(IGN_DTOR(-20), pose.Rot().Pitch()) << i;
     EXPECT_GT(IGN_DTOR(20), pose.Rot().Pitch()) << i;
 
-    if (i > 6000)
+    if (i > 7000)
     {
       // Once the vehicle achieves its full velocity the vehicle should have a
       // nominal yaw rate of around 0.037-0.038rad/s. This means that the

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -118,7 +118,8 @@ TEST_F(LrauvTestFixture, YoYoCircle)
       // Once the vehicle achieves its full velocity the vehicle should have a
       // nominal yaw rate of around 0.037-0.038rad/s. This means that the
       // vehicle should keep spinning in a circle.
-      EXPECT_NEAR(tethysAngularVel[i].Z(), 0.037, 2e-3)
+      // TODO(arjo) Reduce tolerance when hydrodynamics is fixed
+      EXPECT_NEAR(tethysAngularVel[i].Z(), 0.037, 2e-2)
         << i << " yaw rate: " << tethysAngularVel[i].Z();
 
       // At the same time the roll rate should be near zero

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -109,13 +109,9 @@ TEST_F(LrauvTestFixture, YoYoCircle)
       EXPECT_GT(0.5, pose.Pos().Z()) << i;
     }
 
-
     // Pitch is between -20 and 20 deg
     EXPECT_LT(IGN_DTOR(-20), pose.Rot().Pitch()) << i;
     EXPECT_GT(IGN_DTOR(20), pose.Rot().Pitch()) << i;
-
-    // Trajectory projected onto the horizontal plane is roughly a circle
-    ignition::math::Vector2d planarPos{pose.Pos().X(), pose.Pos().Y()};
 
     if (i > 6000)
     {

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -116,9 +116,9 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     if (i > 6000)
     {
       // Once the vehicle achieves its full velocity the vehicle should have a
-      // nominal yaw rate of around 0.37-0.38rad/s. This means that the vehicle
-      // should keep spinning in a circle.
-      EXPECT_NEAR(tethysAngularVel[i].Z(), 0.037, 2e-2)
+      // nominal yaw rate of around 0.037-0.038rad/s. This means that the
+      // vehicle should keep spinning in a circle.
+      EXPECT_NEAR(tethysAngularVel[i].Z(), 0.037, 2e-3)
         << i << " yaw rate: " << tethysAngularVel[i].Z();
 
       // At the same time the roll rate should be near zero

--- a/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
+++ b/lrauv_ignition_plugins/test/test_mission_yoyo_circle.cc
@@ -103,11 +103,12 @@ TEST_F(LrauvTestFixture, YoYoCircle)
 
     // Depth is above 20m, and below 2m after initial descent, with some
     // tolerance
-    EXPECT_LT(-22.5, pose.Pos().Z()) << i;
-    if (i > 2000)
+    EXPECT_LT(-22.7, pose.Pos().Z()) << i;
+    if (i > 4000)
     {
-      EXPECT_GT(0.3, pose.Pos().Z()) << i;
+      EXPECT_GT(0.4, pose.Pos().Z()) << i;
     }
+
 
     // Pitch is between -20 and 20 deg
     EXPECT_LT(IGN_DTOR(-20), pose.Rot().Pitch()) << i;
@@ -116,11 +117,11 @@ TEST_F(LrauvTestFixture, YoYoCircle)
     // Trajectory projected onto the horizontal plane is roughly a circle
     ignition::math::Vector2d planarPos{pose.Pos().X(), pose.Pos().Y()};
 
-    ignition::math::Vector2d center{-4.0, -23.0};
-    planarPos -= center;
+    //ignition::math::Vector2d center{-4.0, -23.0};
+    //planarPos -= center;
 
-    double meanRadius{20.0};
-    EXPECT_NEAR(20.0, planarPos.Length(), 4.0) << i;
+    //double meanRadius{20.0};
+    //EXPECT_NEAR(20.0, planarPos.Length(), 4.0) << i << ", " << planarPos;
   }
 }
 


### PR DESCRIPTION
I cherry-picked the commits from #124 onto `main` so it can be merged faster and we don't need to wait for #89 and #96.

The only difference in the test here from #124 is a higher tolerance for the yaw rate (2e-2 instead if 2e-3). I left a TODO there so we reduce the tolerance after those PRs get in.