### PR TITLE
Fix ocean density on TethysComm

### DIFF
--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -95,7 +95,7 @@
         <joint_name>propeller_joint</joint_name>
         <!-- Be sure to update TethysComm when updating these numbers -->
         <thrust_coefficient>0.004422</thrust_coefficient>
-        <fluid_density>1000</fluid_density>
+        <fluid_density>1025</fluid_density>
         <propeller_diameter>0.2</propeller_diameter>
         <velocity_control>true</velocity_control>
       </plugin>
@@ -153,7 +153,7 @@
         <command_topic>tethys/command_topic</command_topic>
         <state_topic>tethys/state_topic</state_topic>
         <debug_printout>0</debug_printout>
-        <ocean_density>1000</ocean_density>
+        <ocean_density>1025</ocean_density>
       </plugin>
       <plugin
         filename="HydrodynamicsPlugin"

--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -94,7 +94,7 @@
         <namespace>tethys</namespace>
         <joint_name>propeller_joint</joint_name>
         <!-- Be sure to update TethysComm when updating these numbers -->
-        <thrust_coefficient>0.004422</thrust_coefficient>
+        <thrust_coefficient>0.004312328425753156</thrust_coefficient>
         <fluid_density>1025</fluid_density>
         <propeller_diameter>0.2</propeller_diameter>
         <velocity_control>true</velocity_control>

--- a/lrauv_description/test/worlds/flat_world.sdf
+++ b/lrauv_description/test/worlds/flat_world.sdf
@@ -37,7 +37,7 @@
       name="ignition::gazebo::systems::Buoyancy">
       <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102 -->
       <!--<graded_buoyancy>
-        <default_density>1000</default_density>
+        <default_density>1025</default_density>
         <density_change>
           <above_depth>5</above_depth>
           <density>1</density>

--- a/lrauv_description/test/worlds/tilted_world.sdf
+++ b/lrauv_description/test/worlds/tilted_world.sdf
@@ -37,7 +37,7 @@
       name="ignition::gazebo::systems::Buoyancy">
       <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102
         <graded_buoyancy>
-        <default_density>1000</default_density>
+        <default_density>1025</default_density>
         <density_change>
           <above_depth>5</above_depth>
           <density>1</density>

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.cc
@@ -202,7 +202,7 @@ void TethysCommPlugin::Configure(
   {
     this->debugPrintout = _sdf->Get<bool>("debug_printout");
   }
-  if (_sdf->HasElement("density"))
+  if (_sdf->HasElement("ocean_density"))
   {
     this->oceanDensity = _sdf->Get<double>("ocean_density");
   }

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.cc
@@ -421,7 +421,7 @@ void TethysCommPlugin::CommandCallback(
   // force = thrust_coefficient * fluid_density * omega ^ 2 *
   //         propeller_diameter ^ 4
   // These values are defined in the model's Thruster plugin's SDF
-  auto force = 0.004422 * this->oceanDensity * pow(0.2, 4) * angVel * angVel;
+  auto force = 0.004312328425753156 * this->oceanDensity * pow(0.2, 4) * angVel * angVel;
   if (angVel < 0)
   {
     force *=-1;

--- a/lrauv_ignition_plugins/worlds/acoustic_comms_test.sdf
+++ b/lrauv_ignition_plugins/worlds/acoustic_comms_test.sdf
@@ -21,7 +21,7 @@
     <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
-      <uniform_fluid_density>1000</uniform_fluid_density>
+      <uniform_fluid_density>1025</uniform_fluid_density>
     </plugin>
 
     <plugin

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -37,7 +37,7 @@
       name="ignition::gazebo::systems::Buoyancy">
       <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102
         <graded_buoyancy>
-        <default_density>1000</default_density>
+        <default_density>1025</default_density>
         <density_change>
           <above_depth>0.5</above_depth>
           <density>1</density>


### PR DESCRIPTION
* Targeted at #96 

I added a few more water density updates, and fixed a bug on `TethysCommPlugin` that was making it use the wrong water density.