### PR TITLE
Updated new thruster coefficient

### DIFF
--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -94,7 +94,7 @@
         <namespace>tethys</namespace>
         <joint_name>propeller_joint</joint_name>
         <!-- Be sure to update TethysComm when updating these numbers -->
-        <thrust_coefficient>0.004422</thrust_coefficient>
+        <thrust_coefficient>0.004312328425753156</thrust_coefficient>
         <fluid_density>1025</fluid_density>
         <propeller_diameter>0.2</propeller_diameter>
         <velocity_control>true</velocity_control>

--- a/lrauv_ignition_plugins/src/TethysCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/TethysCommPlugin.cc
@@ -421,7 +421,7 @@ void TethysCommPlugin::CommandCallback(
   // force = thrust_coefficient * fluid_density * omega ^ 2 *
   //         propeller_diameter ^ 4
   // These values are defined in the model's Thruster plugin's SDF
-  auto force = 0.004422 * this->oceanDensity * pow(0.2, 4) * angVel * angVel;
+  auto force = 0.004312328425753156 * this->oceanDensity * pow(0.2, 4) * angVel * angVel;
   if (angVel < 0)
   {
     force *=-1;


### PR DESCRIPTION
Resolves #136. This PR updates the thruster coefficient used. The exact math for how it was calculated can be found here:
https://colab.research.google.com/drive/1L-qDb3AYA6JJChWPxn4BU0RppXX8x8t0?usp=sharing