### PR TITLE
A suggestion for a simpler search algorithm for the interpolation

### DIFF
--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -89,15 +89,11 @@ class tethys::ScienceSensorsSystemPrivate
   /// \brief Find XYZ locations of points in the two closest z slices to
   /// interpolate among.
   /// \param[in] _pt Location in space to interpolate for
-  /// \param[in] _inds Indices of nearest neighbors to _pt
-  /// \param[in] _sqrDists Distances of nearest neighbors to _pt
   /// \param[out] _interpolators1 XYZ points on a z slice to interpolate among
   /// \param[out] _interpolators2 XYZ points on a second z slice to interpolate
   /// among
   public: void FindTrilinearInterpolators(
     pcl::PointXYZ &_pt,
-    std::vector<int> &_inds,
-    std::vector<float> &_sqrDists,
     std::vector<pcl::PointXYZ> &_interpolators1,
     std::vector<pcl::PointXYZ> &_interpolators2);
 
@@ -725,8 +721,6 @@ bool ScienceSensorsSystemPrivate::comparePclPoints(
 /////////////////////////////////////////////////
 void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
   pcl::PointXYZ &_pt,
-  std::vector<int> &_inds,
-  std::vector<float> &_sqrDists,
   std::vector<pcl::PointXYZ> &_interpolators1,
   std::vector<pcl::PointXYZ> &_interpolators2)
 {
@@ -747,20 +741,7 @@ void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
   {
     return;
   }
-  if (_inds.size() == 0 || _sqrDists.size() == 0)
-  {
-    ignwarn << "FindInterpolators(): Invalid neighbors aray size ("
-            << _inds.size() << " and " << _sqrDists.size()
-            << "). No neighbors to use for interpolation. Returning NaN."
-            << std::endl;
-    return;
-  }
-  if (_inds.size() != _sqrDists.size())
-  {
-    ignwarn << "FindInterpolators(): Number of neighbors != number of "
-            << "distances. Invalid input. Returning NaN." << std::endl;
-    return;
-  }
+
 
   // Two slices of different depth z values
   pcl::PointCloud<pcl::PointXYZ> zSlice1, zSlice2;
@@ -1535,8 +1516,7 @@ void ScienceSensorsSystem::PostUpdate(const ignition::gazebo::UpdateInfo &_info,
         // Find 2 sets of 4 nearest neighbors, each set on a different z slice,
         // to use as inputs for trilinear interpolation
         std::vector<pcl::PointXYZ> interpolatorsSlice1, interpolatorsSlice2;
-        this->dataPtr->FindTrilinearInterpolators(searchPoint, spatialIdx,
-          spatialSqrDist, interpolatorsSlice1, interpolatorsSlice2);
+        this->dataPtr->FindTrilinearInterpolators(searchPoint, interpolatorsSlice1, interpolatorsSlice2);
         if (interpolatorsSlice1.size() < 4 || interpolatorsSlice2.size() < 4)
         {
           ignwarn << "Could not find trilinear interpolators near sensor location "

--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -727,7 +727,7 @@ void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
   // TODO(tfoote) magic numbers
   // Should be passed in and paramaterized based on the expected data 
   // distribution height or calculated from the grandularity of the dataset.
-  float slice_depth = 100; // 100 meter. 
+  float slice_depth = 5; // 5 meter. 
   float epsilon = 1e-6; // Enough for not equal
 
   // Sanity checks

--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -765,7 +765,7 @@ void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
     interpolatorInds1, interpolatorSqrDists1, _interpolators1);
   if (interpolatorInds1.size() < 4 || interpolatorSqrDists1.size() < 4)
   {
-    ignwarn << "Could not find enough neighbors in 1st slice z = " << _pt.z " or "  << slice_depth << " above"
+    ignwarn << "Could not find enough neighbors in 1st slice z = " << _pt.z << " or "  << slice_depth << " above"
       << " for trilinear interpolation." << std::endl;
     return;
   }
@@ -777,7 +777,7 @@ void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
     interpolatorInds2, interpolatorSqrDists2, _interpolators2);
   if (interpolatorInds2.size() < 4 || interpolatorSqrDists2.size() < 4)
   {
-    ignwarn << "Could not find enough neighbors in 2nd slice z = " << _pt.z " or " << slice_depth << " below"
+    ignwarn << "Could not find enough neighbors in 2nd slice z = " << _pt.z << " or " << slice_depth << " below"
       << " for trilinear interpolation." << std::endl;
     return;
   }

--- a/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
+++ b/lrauv_ignition_plugins/src/ScienceSensorsSystem.cc
@@ -727,7 +727,7 @@ void ScienceSensorsSystemPrivate::FindTrilinearInterpolators(
   // TODO(tfoote) magic numbers
   // Should be passed in and paramaterized based on the expected data 
   // distribution height or calculated from the grandularity of the dataset.
-  float slice_depth = 1; // 1 meter. 
+  float slice_depth = 100; // 100 meter. 
   float epsilon = 1e-6; // Enough for not equal
 
   // Sanity checks


### PR DESCRIPTION
Here's a suggestion for accelerating/simplifying the search algorithm. It's mostly focused on reducing the complexity of the search. There's now just two slice ranges, followed by a closest neighbor search in each of those slices. 

I removed unused parameters: c9130c5dacc69a50918ba3b2dbcf062c5ac9c8f6

The biggest thing that I don't have an immediate answer to is how to set what is currently a magic number of the width of the slice. My first vale of 1m didn't find anything below. And my second try at 100m finds way to many. We should find a way to query this resolution from the dataset or parameterize it somehow. 

Looking at the output it appears that 5m resolution is our current resolution. So I've set it to that. 
