### PR TITLE
Refactor Test Fixture to support different worlds 

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -50,9 +50,8 @@ double angleDiff(double _a, double _b)
   return diff.Radian();
 }
 
-/// \brief Convenient fixture that provides boilerplate code common to most
-/// LRAUV tests. This is an abstract class that does not provide any concrete
-/// worlds.
+/// \brief Abstract base class for fixture that provides boilerplate code common
+/// to most LRAUV tests.
 class LrauvTestFixtureBase : public ::testing::Test
 {
   // Setup the specified world.

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -51,11 +51,13 @@ double angleDiff(double _a, double _b)
 }
 
 /// \brief Convenient fixture that provides boilerplate code common to most
-/// LRAUV tests.
-class LrauvTestFixture : public ::testing::Test
+/// LRAUV tests. This is an abstract class that does not provide any concrete
+/// worlds.
+class LrauvTestFixtureBase : public ::testing::Test
 {
-  // Documentation inherited
-  protected: void SetUp() override
+  // Setup the specified world.
+  // \param[in] _worldName Name of the world to load.
+  public: void SetUp(const std::string &_worldName)
   {
     ignition::common::Console::SetVerbosity(4);
 
@@ -66,12 +68,12 @@ class LrauvTestFixture : public ::testing::Test
       commandTopic);
 
     auto stateTopic = "/tethys/state_topic";
-    this->node.Subscribe(stateTopic, &LrauvTestFixture::OnState, this);
+    this->node.Subscribe(stateTopic, &LrauvTestFixtureBase::OnState, this);
 
     // Setup fixture
     this->fixture = std::make_unique<ignition::gazebo::TestFixture>(
         ignition::common::joinPaths(
-        std::string(PROJECT_SOURCE_PATH), "worlds", "buoyant_tethys.sdf"));
+        std::string(PROJECT_SOURCE_PATH), "worlds", _worldName));
 
     fixture->OnPostUpdate(
       [&](const ignition::gazebo::UpdateInfo &_info,
@@ -301,5 +303,16 @@ class LrauvTestFixture : public ::testing::Test
 
   /// \brief Publishes commands
   public: ignition::transport::Node::Publisher commandPub;
+};
+
+
+/// \brief Loads the default "buyant_tethys.sdf" world.
+class LrauvTestFixture : public LrauvTestFixtureBase
+{
+  /// Documentation inherited
+  protected: void SetUp() override
+  {
+    LrauvTestFixtureBase::SetUp("buoyant_tethys.sdf");
+  }
 };
 #endif

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -54,8 +54,8 @@ double angleDiff(double _a, double _b)
 /// to most LRAUV tests.
 class LrauvTestFixtureBase : public ::testing::Test
 {
-  // Setup the specified world.
-  // \param[in] _worldName Name of the world to load.
+  /// Setup the specified world.
+  /// \param[in] _worldName Name of the world to load.
   public: void SetUp(const std::string &_worldName)
   {
     ignition::common::Console::SetVerbosity(4);
@@ -308,7 +308,7 @@ class LrauvTestFixtureBase : public ::testing::Test
 /// \brief Loads the default "buyant_tethys.sdf" world.
 class LrauvTestFixture : public LrauvTestFixtureBase
 {
-  /// Documentation inherited
+  // Documentation inherited
   protected: void SetUp() override
   {
     LrauvTestFixtureBase::SetUp("buoyant_tethys.sdf");


### PR DESCRIPTION
Currently, the `LrauvTestFixture` allows us to only load `BuoyantTethys.sdf`. This PR refactors the test fixture. It creates two test classes:
* `LrauvTestFixtureBase` - An abstract base class which contains all the common functionality.
* `LrauvTestFixture` - Inherits from `LrauvTestFixtureBase` and loads the `buoyant_tethys.sdf`.
