### PR TITLE
Add surface to buoyant_tethys

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -314,4 +314,14 @@ class LrauvTestFixture : public LrauvTestFixtureBase
     LrauvTestFixtureBase::SetUp("buoyant_tethys.sdf");
   }
 };
+
+/// \brief Loads the default "buyant_tethys.sdf" world.
+class LrauvTestFixtureAtDepth : public LrauvTestFixtureBase
+{
+  /// Documentation inherited
+  protected: void SetUp() override
+  {
+    LrauvTestFixtureBase::SetUp("buoyant_tethys_at_depth.sdf");
+  }
+};
 #endif

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -50,9 +50,8 @@ double angleDiff(double _a, double _b)
   return diff.Radian();
 }
 
-/// \brief Convenient fixture that provides boilerplate code common to most
-/// LRAUV tests. This is an abstract class that does not provide any concrete
-/// worlds.
+/// \brief Abstract base class for fixture that provides boilerplate code common
+/// to most LRAUV tests.
 class LrauvTestFixtureBase : public ::testing::Test
 {
   // Setup the specified world.

--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -51,11 +51,13 @@ double angleDiff(double _a, double _b)
 }
 
 /// \brief Convenient fixture that provides boilerplate code common to most
-/// LRAUV tests.
-class LrauvTestFixture : public ::testing::Test
+/// LRAUV tests. This is an abstract class that does not provide any concrete
+/// worlds.
+class LrauvTestFixtureBase : public ::testing::Test
 {
-  // Documentation inherited
-  protected: void SetUp() override
+  // Setup the specified world.
+  // \param[in] _worldName Name of the world to load.
+  public: void SetUp(const std::string &_worldName)
   {
     ignition::common::Console::SetVerbosity(4);
 
@@ -66,12 +68,12 @@ class LrauvTestFixture : public ::testing::Test
       commandTopic);
 
     auto stateTopic = "/tethys/state_topic";
-    this->node.Subscribe(stateTopic, &LrauvTestFixture::OnState, this);
+    this->node.Subscribe(stateTopic, &LrauvTestFixtureBase::OnState, this);
 
     // Setup fixture
     this->fixture = std::make_unique<ignition::gazebo::TestFixture>(
         ignition::common::joinPaths(
-        std::string(PROJECT_SOURCE_PATH), "worlds", "buoyant_tethys.sdf"));
+        std::string(PROJECT_SOURCE_PATH), "worlds", _worldName));
 
     fixture->OnPostUpdate(
       [&](const ignition::gazebo::UpdateInfo &_info,
@@ -301,5 +303,16 @@ class LrauvTestFixture : public ::testing::Test
 
   /// \brief Publishes commands
   public: ignition::transport::Node::Publisher commandPub;
+};
+
+
+/// \brief Loads the default "buyant_tethys.sdf" world.
+class LrauvTestFixture : public LrauvTestFixtureBase
+{
+  /// Documentation inherited
+  protected: void SetUp() override
+  {
+    LrauvTestFixtureBase::SetUp("buoyant_tethys.sdf");
+  }
 };
 #endif

--- a/lrauv_ignition_plugins/test/test_mass_shifter.cc
+++ b/lrauv_ignition_plugins/test/test_mass_shifter.cc
@@ -29,7 +29,7 @@
 #include <fstream>
 
 //////////////////////////////////////////////////
-TEST_F(LrauvTestFixture, MassShifterTilt)
+TEST_F(LrauvTestFixtureAtDepth, MassShifterTilt)
 {
   // Check initial orientation
   this->fixture->Server()->Run(true, 100, false);

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -40,7 +40,7 @@
         <default_density>1025</default_density>
         <density_change>
           <above_depth>0.5</above_depth>
-          <density>0</density>
+          <density>1.125</density>
         </density_change>
       </graded_buoyancy>
       <!--<uniform_fluid_density>1025</uniform_fluid_density> -->

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
@@ -357,7 +357,7 @@
     </include-->
 
     <include>
-      <pose>0 0 0 0 0 0</pose>
+      <pose>0 0 -10 0 0 0</pose>
       <uri>tethys_equipped</uri>
     </include>
 

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
@@ -3,6 +3,12 @@
   Development of this module has been funded by the Monterey Bay Aquarium
   Research Institute (MBARI) and the David and Lucile Packard Foundation
 -->
+
+<!--
+  This file is essentially identical to buoyant_tethys, except the vehicle
+  starts at a depth of -10m instead of 0m. This is for tests that require the
+  vehicle to be fully submerged.
+-->
 <sdf version="1.6">
   <world name="buoyant_tethys">
     <scene>
@@ -40,10 +46,9 @@
         <default_density>1025</default_density>
         <density_change>
           <above_depth>0.5</above_depth>
-          <density>0</density>
+          <density>1.125</density>
         </density_change>
       </graded_buoyancy>
-      <!--<uniform_fluid_density>1025</uniform_fluid_density> -->
     </plugin>
 
     <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied


### PR DESCRIPTION
Depends on #160

This PR adds a surface at z=0 to the default `buoyant_tethy.sdf`.  Most things work as expected. I had to move the MassShifter test deeper underwater as the vehicle would not pitch enough at the surface (kind of expected I guess?). I moved the mass shifter test deeper underwater.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>