### PR TITLE
Modifies the dropweight test to test for breaching the surface.

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -315,7 +315,8 @@ class LrauvTestFixture : public LrauvTestFixtureBase
   }
 };
 
-/// \brief Loads the default "buyant_tethys.sdf" world.
+/// \brief Loads the default "buyant_tethys_At_depth.sdf" world.
+/// This world has the robot start at a certain depth.
 class LrauvTestFixtureAtDepth : public LrauvTestFixtureBase
 {
   /// Documentation inherited


### PR DESCRIPTION
Depends on #161, #160

This PR validates the behaviour of the dropweight with the surface of the water. It modifies the drop weight test such that the vehicle is started at a 10m depth and we monitor its rise. The test makes sure that we do not exceed a height of 0.5m (this tolerance is required to account for the oscillations introduces by the transition).

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>