### PR TITLE
State message: populate UVW and PQR rates

### DIFF
--- a/lrauv_ignition_plugins/proto/lrauv_state.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_state.proto
@@ -46,8 +46,13 @@ import "ignition/msgs/vector3d.proto";
 //     * Pitch: Right-hand rotation about East
 //     * Yaw: Right-hand rotation about Down
 //
-// TODO(chapulina)
-// * Vehicle frame: FSK 
+// * Vehicle frame: FSK
+//     * X: Fore or forward
+//     * Y: Starboard or right
+//     * Z: Keel or down
+//     * Roll: Clockwise rotation when looking from the back.
+//     * Pitch: Positive angles bring the nose up.
+//     * Yaw: Positive angles bring the nose to the right / starboard.
 //
 message LRAUVState
 {
@@ -122,14 +127,16 @@ message LRAUVState
   /// \brief Vehicle's orientation in "world frame" (see above) Unit: rad
   ignition.msgs.Vector3d posRPH_  = 20;
 
-  /// \brief Vehicle's instantaneous linear velocity in "world frame" 
+  /// \brief Vehicle's instantaneous linear velocity in "world frame"
   /// (see above). Units: m / s
   ignition.msgs.Vector3d posDot_  = 21;
 
-  /// \brief \TODO(chapulina)
+  /// \brief Vehicle's instantaneous linear velocity in "vehicle frame" (see above).
+  /// Units: m / s
   ignition.msgs.Vector3d rateUVW_ = 22;
 
-  /// \brief \TODO(chapulina)
+  /// \brief Vehicle's instantaneous angular velocity in "vehicle frame" (see above).
+  /// Units: rad / s
   ignition.msgs.Vector3d ratePQR_ = 23;
 
   /// \brief Northward sea water velocity collected from current sensor. Unit: m/s.

--- a/lrauv_ignition_plugins/test/test_state_msg.cc
+++ b/lrauv_ignition_plugins/test/test_state_msg.cc
@@ -43,9 +43,6 @@ void commonChecks(const lrauv_ignition_plugins::msgs::LRAUVState &_msg)
 //////////////////////////////////////////////////
 TEST_F(LrauvTestFixture, State)
 {
-  // TODO(chapulina) Test other fields, see
-  // https://github.com/osrf/lrauv/pull/81
-
   // Initial state
   this->fixture->Server()->Run(true, 100, false);
   int maxSleep{100};
@@ -88,6 +85,15 @@ TEST_F(LrauvTestFixture, State)
   EXPECT_NEAR(0.0, latest.posdot_().x(), 1e-6);
   EXPECT_NEAR(0.0, latest.posdot_().y(), 1e-6);
   EXPECT_NEAR(0.0, latest.posdot_().z(), 1e-6);
+
+  // FSK vehicle frame
+  EXPECT_NEAR(0.0, latest.rateuvw_().x(), 1e-6);
+  EXPECT_NEAR(0.0, latest.rateuvw_().y(), 1e-6);
+  EXPECT_NEAR(0.0, latest.rateuvw_().z(), 1e-6);
+
+  EXPECT_NEAR(0.0, latest.ratepqr_().x(), 1e-6);
+  EXPECT_NEAR(0.0, latest.ratepqr_().y(), 1e-6);
+  EXPECT_NEAR(0.0, latest.ratepqr_().z(), 1e-6);
 
   // TODO(chapulina) Check sensor data once interpolation is complete
   // https://github.com/osrf/lrauv/issues/5
@@ -144,6 +150,15 @@ TEST_F(LrauvTestFixture, State)
   EXPECT_NEAR(0.0, latest.posdot_().y(), 1e-4);
   EXPECT_NEAR(0.0, latest.posdot_().z(), 1e-6);
 
+  // FSK vehicle frame: vehicle is going forward
+  EXPECT_NEAR(1.0, latest.rateuvw_().x(), 0.02);
+  EXPECT_NEAR(0.0, latest.rateuvw_().y(), 1e-4);
+  EXPECT_NEAR(0.0, latest.rateuvw_().z(), 1e-6);
+
+  EXPECT_NEAR(0.0, latest.ratepqr_().x(), 1e-3);
+  EXPECT_NEAR(0.0, latest.ratepqr_().y(), 1e-6);
+  EXPECT_NEAR(0.0, latest.ratepqr_().z(), 1e-5);
+
   // Keep propelling vehicle forward
   cmdMsg.set_propomegaaction_(10 * IGN_PI);
 
@@ -199,6 +214,15 @@ TEST_F(LrauvTestFixture, State)
   EXPECT_LT(0.3, latest.posdot_().y());
   EXPECT_NEAR(0.0, latest.posdot_().z(), 1e-3);
 
+  // FSK vehicle frame: vehicle is going mostly forward and rotating right.
+  EXPECT_LT(0.8, latest.rateuvw_().x());
+  EXPECT_GT(0.2, abs(latest.rateuvw_().y()));
+  EXPECT_NEAR(0.0, latest.rateuvw_().z(), 1e-3);
+
+  EXPECT_NEAR(0.0, latest.ratepqr_().x(), 1e-2);
+  EXPECT_NEAR(0.0, latest.ratepqr_().y(), 1e-3);
+  EXPECT_NEAR(0.1, latest.ratepqr_().z(), 1e-2);
+
   // Stop propelling and rotating vehicle
   cmdMsg.set_propomegaaction_(0);
   cmdMsg.set_rudderangleaction_(0);
@@ -232,5 +256,8 @@ TEST_F(LrauvTestFixture, State)
   // Velocity
   // NED world frame: sinking to higher Z
   EXPECT_LT(0.02, latest.posdot_().z());
+
+  // FSK vehicle frame: downwards velocity
+  EXPECT_LT(0.01, latest.rateuvw_().z());
 }
 


### PR DESCRIPTION
Wrapping up #48 :checkered_flag: :raised_hands: :smiling_face_with_tear: 

This PR populates `ratePQR` and `rateUVW`, which are the quantities expressed in the FSK frame.

Note that the model itself is oriented as "SFU" (starboard, forward, up). See discussion on #48 on why it was tough to orient the model as FSK and save the extra transform. One way to visualize the SFU frame is using the transform control tool:

**ENU** :point_down: .................................................................. **FSK** :point_down:  / **SFU** :sparkles: .....................................................................  **NED** :point_down: 
![sfu](https://user-images.githubusercontent.com/5751272/156460693-b64d178a-27a8-4d9f-9488-15c57d7abb26.gif)

