### PR TITLE
Disables buoyancy engine above the surface

### DIFF
--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -197,6 +197,8 @@
         <max_volume>0.000955</max_volume>
         <!-- m^3/s -->
         <max_inflation_rate>0.000003</max_inflation_rate>
+        <!-- Default surface at 0m -->
+        <surface>0</surface>
       </plugin>
       <plugin
         filename="ignition-gazebo-detachable-joint-system"

--- a/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_depth_vbs.cc
@@ -41,8 +41,8 @@ TEST_F(LrauvTestFixture, DepthVBS)
   EXPECT_EQ(10, this->tethysPoses.size());
   EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().X(), 1e-6);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Y(), 1e-6);
-  EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Z(), 1e-6);
-  EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Roll(), 1e-6);
+  EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Z(), 1e-3);
+  EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Roll(), 1e-3);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Pitch(), 1e-6);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Yaw(), 1e-6);
 

--- a/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
+++ b/lrauv_ignition_plugins/test/test_mission_pitch_and_depth_mass_vbs.cc
@@ -41,8 +41,8 @@ TEST_F(LrauvTestFixture, PitchDepthVBS)
   EXPECT_EQ(10, this->tethysPoses.size());
   EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().X(), 1e-6);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Y(), 1e-6);
-  EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Z(), 1e-6);
-  EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Roll(), 1e-6);
+  EXPECT_NEAR(0.0, this->tethysPoses.back().Pos().Z(), 1e-3);
+  EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Roll(), 1e-3);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Pitch(), 1e-6);
   EXPECT_NEAR(0.0, this->tethysPoses.back().Rot().Yaw(), 1e-6);
 

--- a/lrauv_ignition_plugins/test/test_state_msg.cc
+++ b/lrauv_ignition_plugins/test/test_state_msg.cc
@@ -41,7 +41,7 @@ void commonChecks(const lrauv_ignition_plugins::msgs::LRAUVState &_msg)
 }
 
 //////////////////////////////////////////////////
-TEST_F(LrauvTestFixture, State)
+TEST_F(LrauvTestFixtureAtDepth, State)
 {
   // TODO(chapulina) Test other fields, see
   // https://github.com/osrf/lrauv/pull/81
@@ -68,14 +68,14 @@ TEST_F(LrauvTestFixture, State)
   // Position
   ignition::math::Angle initialLat(IGN_DTOR(35.5999984741211));
   ignition::math::Angle initialLon(IGN_DTOR(-121.779998779297));
-  EXPECT_NEAR(0.0, latest.depth_(), 1e-6);
+  EXPECT_NEAR(10.0, latest.depth_(), 1e-6);
   EXPECT_NEAR(initialLat.Degree(), latest.latitudedeg_(), 1e-6);
   EXPECT_NEAR(initialLon.Degree(), latest.longitudedeg_(), 1e-6);
 
-  // Starts aligned with NED world frame (zero pose facing North)
+  // Starts aligned with NED world frame (zero pose facing North) @ 10m depth
   EXPECT_NEAR(0.0, latest.pos_().x(), 1e-6);
   EXPECT_NEAR(0.0, latest.pos_().y(), 1e-6);
-  EXPECT_NEAR(0.0, latest.pos_().z(), 1e-6);
+  EXPECT_NEAR(10.0, latest.pos_().z(), 1e-6);
 
   EXPECT_NEAR(0.0, latest.posrph_().x(), 1e-6);
   EXPECT_NEAR(0.0, latest.posrph_().y(), 1e-6);
@@ -124,14 +124,14 @@ TEST_F(LrauvTestFixture, State)
   EXPECT_NEAR(0.0005, latest.buoyancyposition_(), 1e-6);
 
   // Position
-  EXPECT_NEAR(0.0, latest.depth_(), 1e-6);
+  EXPECT_NEAR(10.0, latest.depth_(), 1e-6);
   EXPECT_LT(initialLat.Degree(), latest.latitudedeg_());
   EXPECT_NEAR(initialLon.Degree(), latest.longitudedeg_(), 1e-6);
 
   // NED world frame: vehicle is going North with no rotation
   EXPECT_LT(28.0, latest.pos_().x());
   EXPECT_NEAR(0.0, latest.pos_().y(), 1e-3);
-  EXPECT_NEAR(0.0, latest.pos_().z(), 1e-6);
+  EXPECT_NEAR(10.0, latest.pos_().z(), 1e-6);
   EXPECT_NEAR(0.0, latest.posrph_().x(), 1e-3);
   EXPECT_NEAR(0.0, latest.posrph_().y(), 1e-6);
   EXPECT_NEAR(0.0, latest.posrph_().z(), 1e-5);
@@ -179,14 +179,14 @@ TEST_F(LrauvTestFixture, State)
   EXPECT_NEAR(0.0005, latest.buoyancyposition_(), 1e-6);
 
   // Position
-  EXPECT_NEAR(0.0, latest.depth_(), 1e-3);
+  EXPECT_NEAR(10.0, latest.depth_(), 1e-3);
   EXPECT_LT(initialLat.Degree(), latest.latitudedeg_());
   EXPECT_LT(initialLon.Degree(), latest.longitudedeg_());
 
   // NED world frame: vehicle is going North East with positive yaw
   EXPECT_LT(30.0, latest.pos_().x());
   EXPECT_LT(0.4, latest.pos_().y());
-  EXPECT_NEAR(0.0, latest.pos_().z(), 1e-3);
+  EXPECT_NEAR(10.0, latest.pos_().z(), 1e-3);
   EXPECT_NEAR(0.0, latest.posrph_().x(), 1e-3);
   EXPECT_NEAR(0.0, latest.posrph_().y(), 1e-3);
   EXPECT_LT(0.5, latest.posrph_().z());

--- a/lrauv_ignition_plugins/worlds/star_world.sdf
+++ b/lrauv_ignition_plugins/worlds/star_world.sdf
@@ -69,6 +69,11 @@
       <pose>-5 0 1 0 0 0</pose>
       <uri>tethys_equipped</uri>
       <name>tethys</name>
+      <experimental:params>
+        <plugin element_id="ignition::gazebo::systems::BuoyancyEngine" action="modify">
+          <surface>1000</surface>
+        </plugin>
+      </experimental:params>
     </include>
 
     <include>
@@ -98,6 +103,7 @@
         </plugin>
         <plugin element_id="ignition::gazebo::systems::BuoyancyEngine" action="modify">
           <namespace>tethys2</namespace>
+          <surface>1000</surface>
         </plugin>
         <plugin element_id="ignition::gazebo::systems::DetachableJoint" action="modify">
           <topic>/model/tethys2/drop_weight</topic>
@@ -139,6 +145,7 @@
         </plugin>
         <plugin element_id="ignition::gazebo::systems::BuoyancyEngine" action="modify">
           <namespace>tethys3</namespace>
+          <surface>1000</surface>
         </plugin>
         <plugin element_id="ignition::gazebo::systems::DetachableJoint" action="modify">
           <topic>/model/tethys3/drop_weight</topic>
@@ -180,6 +187,7 @@
         </plugin>
         <plugin element_id="ignition::gazebo::systems::BuoyancyEngine" action="modify">
           <namespace>tethys4</namespace>
+          <surface>1000</surface>
         </plugin>
         <plugin element_id="ignition::gazebo::systems::DetachableJoint" action="modify">
           <topic>/model/tethys4/drop_weight</topic>
@@ -192,10 +200,7 @@
           <namespace>tethys4</namespace>
         </plugin>
       </experimental:params>
-
     </include>
-
-
 
   </world>
 </sdf>


### PR DESCRIPTION
This PR disables the buoyancy engine's upward forces when the vehicle surfaces. I suspect this may have had something to do with the vehicle going 90 degrees. Need to write a test to verify if this solves the robot pitchoing 90 degrees problem.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>