### PR TITLE
spawn vehicles with acomms address

### DIFF
--- a/lrauv_ignition_plugins/proto/lrauv_init.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_init.proto
@@ -62,5 +62,8 @@ message LRAUVInit
   /// (i.e. rotation about the Down vector). Radians.
   float initHeading_              = 8;
 
+  /// \brief Unique acoustic comms modem ID
+  uint32 acommsAddress_           = 9;
+
   // Add fields as needed
 }

--- a/lrauv_ignition_plugins/src/WorldCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.cc
@@ -161,7 +161,7 @@ void WorldCommPlugin::SpawnCallback(
 
   // Create vehicle
   ignition::msgs::EntityFactory factoryReq;
-  factoryReq.set_sdf(this->TethysSdfString(_msg.id_().data()));
+  factoryReq.set_sdf(this->TethysSdfString(_msg));
 
   auto coords = factoryReq.mutable_spherical_coordinates();
   coords->set_surface_model(ignition::msgs::SphericalCoordinates::EARTH_WGS84);
@@ -207,8 +207,11 @@ void WorldCommPlugin::SpawnCallback(
 }
 
 /////////////////////////////////////////////////
-std::string WorldCommPlugin::TethysSdfString(const std::string &_id)
+std::string WorldCommPlugin::TethysSdfString(const lrauv_ignition_plugins::msgs::LRAUVInit &_msg)
 {
+  const std::string _id = _msg.id_().data();
+  const std::string _acommsAddress = std::to_string(_msg.acommsaddress_());
+
   const std::string sdfStr = R"(
   <sdf version="1.9">
   <model name=")" + _id + R"(">
@@ -261,6 +264,15 @@ std::string WorldCommPlugin::TethysSdfString(const std::string &_id)
 
         <plugin element_id="ignition::gazebo::systems::DetachableJoint" action="modify">
           <topic>/model/)" + _id + R"(/drop_weight</topic>
+        </plugin>
+
+        <plugin element_id="tethys::AcousticCommsPlugin" action="modify">
+          <address>)" + _acommsAddress + R"(</address>
+        </plugin>
+
+        <plugin element_id="tethys::RangeBearingPlugin" action="modify">
+          <address>)" + _acommsAddress + R"(</address>
+          <namespace>)" + _id + R"(</namespace>
         </plugin>
 
       </experimental:params>

--- a/lrauv_ignition_plugins/src/WorldCommPlugin.hh
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.hh
@@ -53,10 +53,11 @@ namespace tethys
     public: void SpawnCallback(
                 const lrauv_ignition_plugins::msgs::LRAUVInit &_msg);
 
-    /// Get the SDF string for a Tethys model with the given ID.
-    /// \param[in] _id Used as model name and namespace for topics.
+    /// Get the SDF string for a Tethys model with given ID and acoustic modem address.
+    /// \param[in] _msg LRAUV init message containing ID and acoustic modem address.
     /// \return SDF string
-    public: std::string TethysSdfString(const std::string &_id);
+    public: std::string TethysSdfString(
+                const lrauv_ignition_plugins::msgs::LRAUVInit &_msg);
 
     /// Generic callback to handle service responses.
     /// \param[in] _rep Response

--- a/lrauv_ignition_plugins/test/test_spawn.cc
+++ b/lrauv_ignition_plugins/test/test_spawn.cc
@@ -116,6 +116,7 @@ TEST(SpawnTest, Spawn)
     spawnMsg.mutable_id_()->set_data("vehicle1");
     spawnMsg.set_initlat_(lat1.Degree());
     spawnMsg.set_initlon_(lon1.Degree());
+    spawnMsg.set_acommsaddress_(666);
 
     spawnPub.Publish(spawnMsg);
   }
@@ -154,6 +155,7 @@ TEST(SpawnTest, Spawn)
     spawnMsg.set_initroll_(0.0);
     spawnMsg.set_initpitch_(0.0);
     spawnMsg.set_initheading_(yaw2.Radian());
+    spawnMsg.set_acommsaddress_(999);
 
     spawnPub.Publish(spawnMsg);
   }
@@ -214,4 +216,3 @@ TEST(SpawnTest, Spawn)
   EXPECT_NEAR(0.0, poses2.back().Rot().Pitch(), tightTol);
   EXPECT_NEAR(IGN_DTOR(90), poses2.back().Rot().Yaw(), tightTol);
 }
-

--- a/lrauv_ignition_plugins/test/test_spawn.cc
+++ b/lrauv_ignition_plugins/test/test_spawn.cc
@@ -116,7 +116,7 @@ TEST(SpawnTest, Spawn)
     spawnMsg.mutable_id_()->set_data("vehicle1");
     spawnMsg.set_initlat_(lat1.Degree());
     spawnMsg.set_initlon_(lon1.Degree());
-    spawnMsg.set_acommsaddress_(666);
+    spawnMsg.set_acommsaddress_(201);
 
     spawnPub.Publish(spawnMsg);
   }
@@ -155,7 +155,7 @@ TEST(SpawnTest, Spawn)
     spawnMsg.set_initroll_(0.0);
     spawnMsg.set_initpitch_(0.0);
     spawnMsg.set_initheading_(yaw2.Radian());
-    spawnMsg.set_acommsaddress_(999);
+    spawnMsg.set_acommsaddress_(202);
 
     spawnPub.Publish(spawnMsg);
   }
@@ -176,6 +176,14 @@ TEST(SpawnTest, Spawn)
   EXPECT_LT(0, poses2.size());
   EXPECT_LT(1, latLon1.size());
   EXPECT_LT(0, latLon2.size());
+
+  // Check if an acomms topic was generated with the correct modem adderss
+  std::vector<std::string> topics;
+  node.TopicList(topics);
+  EXPECT_TRUE(std::any_of(topics.begin(),
+                          topics.end(),
+                          [](const std::string &s)
+                          { return s == "/comms/external/202/tx"; }));
 
   double tightTol{1e-5};
 


### PR DESCRIPTION
This PR adds an acomms modem address entry to `lrauv_init` message and modifies the SDF string formulation in `WorldCommPlugin` to propagate the specified address to a spawned vehicle. 

This PR depends on [#376](https://bitbucket.org/mbari/lrauv-application/pull-requests/376/byraanan-ign-init-acomms-address) in lrauv-application.

The acomms modem address is specified by the `Vehicle.id` configuration parameter in LRAUV application. That config can be found under `Config/vehicle.cfg`.

@chapulina, Louise, I added calls to set the acomms address for spawned vehicles in [lrauv_ignition_plugins/test/test_spawn.cc](https://github.com/osrf/lrauv/compare/braanan/init_acomms_address?expand=1#diff-da5f11524c6c0f34dbe1bd06604a8755c0f01bdedbb3da7d95b8922daaa01c2e). Can you suggest a way to assert that the address has been set correctly in the spawned vehicles?

Thanks!