### PR TITLE
update test fixture to report faults instead of errors

### DIFF
--- a/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvTestFixture.hh
@@ -229,9 +229,9 @@ class LrauvTestFixtureBase : public ::testing::Test
       // See https://github.com/osrf/lrauv/issues/83
       std::string bufferStr{buffer};
 
-      std::string error{"ERROR"};
+      std::string fault{"FAULT"};
       std::string critical{"CRITICAL"};
-      if (bufferStr.find(error) != std::string::npos ||
+      if (bufferStr.find(fault) != std::string::npos ||
           bufferStr.find(critical) != std::string::npos)
       {
         ignerr << buffer << "\n";


### PR DESCRIPTION
@chapulina, @arjo129 Hi Luise and Arjo,

This is a minor change to the test fixture to output more relevant error info from the lrauv-application during testing. In the lrauv-app only FAULT and CRITICAL logging priorities are important.

Thanks!