### PR TITLE
Point our Docker images to the latest

### DIFF
--- a/docker/debug_integration/Dockerfile
+++ b/docker/debug_integration/Dockerfile
@@ -19,7 +19,7 @@
 # Research Institute (MBARI) and the David and Lucile Packard Foundation
 #
 
-FROM mbari/lrauv-ignition-sim:garden
+FROM mbari/lrauv-ignition-sim:latest
 
 USER root
 

--- a/docker/tests/Dockerfile
+++ b/docker/tests/Dockerfile
@@ -19,7 +19,7 @@
 # Research Institute (MBARI) and the David and Lucile Packard Foundation
 #
 
-FROM mbari/lrauv-ignition-sim:garden
+FROM mbari/lrauv-ignition-sim:latest
 
 USER root
 


### PR DESCRIPTION
Currently all our tests are failing because the garden tagged images were removed. This retargets the tests to use the latest tag.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>