### PR TITLE
Use world origin spherical coordinates from SDF if set

### DIFF
--- a/lrauv_ignition_plugins/src/WorldCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.cc
@@ -105,6 +105,12 @@ void WorldCommPlugin::Configure(
   this->createService = "/world/" + topicWorldName + "/create";
   this->setSphericalCoordsService = "/world/" + topicWorldName
     + "/set_spherical_coordinates";
+
+  // We assume that the world origin spherical coordinates will either be set
+  // through SDF, or through this plugin. This assumption is broken if a user
+  // sets it manually.
+  this->hasWorldLatLon =
+      ignition::gazebo::sphericalCoordinates(worldEntity, _ecm).has_value();
 }
 
 /////////////////////////////////////////////////
@@ -133,7 +139,7 @@ void WorldCommPlugin::SpawnCallback(
   auto ele = -_msg.initz_();
 
   // Center the world around the first vehicle spawned
-  if (this->spawnCount == 0)
+  if (!this->hasWorldLatLon)
   {
     igndbg << "Setting world origin coordinates to latitude [" << lat
            << "], longitude [" << lon << "], elevation [" << ele << "]"
@@ -156,8 +162,11 @@ void WorldCommPlugin::SpawnCallback(
       ignerr << "Failed to request service [" << this->setSphericalCoordsService
              << "]" << std::endl;
     }
+    else
+    {
+      this->hasWorldLatLon = true;
+    }
   }
-  this->spawnCount++;
 
   // Create vehicle
   ignition::msgs::EntityFactory factoryReq;

--- a/lrauv_ignition_plugins/src/WorldCommPlugin.hh
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.hh
@@ -36,6 +36,9 @@ namespace tethys
 {
   /// Listens to LRAUVInit messages from the controller to spawn vehicles
   /// into simulation.
+  ///
+  /// If the world origin's spherical coordinates aren't set from SDF, this
+  /// plugin will set them to match the first vehicle spawned.
   class WorldCommPlugin:
     public ignition::gazebo::System,
     public ignition::gazebo::ISystemConfigure
@@ -77,8 +80,8 @@ namespace tethys
     /// Service to create entities
     private: std::string createService;
 
-    /// Count how many vehicles have been spawned
-    private: int spawnCount{0};
+    /// Whether the world origin's latitude and longitude have already been set.
+    private: bool hasWorldLatLon{false};
   };
 }
 


### PR DESCRIPTION
* Part of #146 

---

Originally, `WorldCommPlugin` would set the world origin to coincide with the first spawned vehicle and ignore the coordinates set from SDF. This is useful for generic simulation worlds that can be used for multiple scenarios.

But for #146 , we're creating a world that has environment features that need to be precisely geolocated. This means that we need to set the world origin before any vehicles are spawned.

This PR makes sure we support both cases:

* If `<sperical_coordinates>` isn't set from SDF, it will be set when the first vehicle is spawned.
* If it is set, then all vehicles are spawned w.r.t. that origin

### Test it

Case when there's on `<spherical_coordinates>`:

1. `ign gazebo empty_environment.sdf`
2. See on inspector that there are no spherical coordinates yet
3. `bin/LRAUV`
4. The vehicle is spawned at the origin and the world now has spherical coordinates

Case when there's `<spherical_coordinates>`:

1. Edit `empty_environment.sdf` to add spherical coordinates:
    ```diff
    diff --git a/lrauv_ignition_plugins/worlds/empty_environment.sdf b/lrauv_ignition_plugins/worlds/empty_environment.sdf
    index ce76e0b..2a2f914 100644
    --- a/lrauv_ignition_plugins/worlds/empty_environment.sdf
    +++ b/lrauv_ignition_plugins/worlds/empty_environment.sdf
    @@ -56,6 +56,16 @@       
           name="tethys::TimeAnalysisPlugin">
         </plugin-->       
                                                                   
    +    <spherical_coordinates>                                                                                                                   
    +      <surface_model>EARTH_WGS84</surface_model>                                                                                              
    +      <world_frame_orientation>ENU</world_frame_orientation>                                                                                  
    +      <latitude_deg>36.803500000000</latitude_deg>                                                                                                                                                           
    +      <longitude_deg>-121.822200000000</longitude_deg>           
    +      <elevation>0</elevation>                                                                                                                
    +      <heading_deg>0</heading_deg>
    +    </spherical_coordinates>                                       
    +                                                                   
         <plugin                                                        
           filename="ScienceSensorsSystem"                    
           name="tethys::ScienceSensorsSystem">
    ```
1. `ign gazebo empty_environment.sdf`
3. See on inspector that there are spherical coordinates
4. `bin/LRAUV`
5. The vehicle is spawned far from the origin
