### PR TITLE
Spawn vehicle with correct AHRS topic names

### DIFF
--- a/lrauv_ignition_plugins/src/WorldCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.cc
@@ -248,6 +248,14 @@ std::string WorldCommPlugin::TethysSdfString(const lrauv_ignition_plugins::msgs:
           <topic>/model/)" + _id + R"(/current</topic>
         </sensor>
 
+        <sensor element_id="base_link::sparton_ahrs_m2_imu" action="modify">
+          <topic>/)" + _id + R"(/ahrs/imu</topic>
+        </sensor>
+
+        <sensor element_id="base_link::ahrs_magnetometer" action="modify">
+          <topic>/)" + _id + R"(/ahrs/magnetometer</topic>
+        </sensor>
+
         <plugin element_id="ignition::gazebo::systems::Thruster" action="modify">
           <namespace>)" + _id + R"(</namespace>
         </plugin>

--- a/lrauv_ignition_plugins/worlds/empty_environment.sdf
+++ b/lrauv_ignition_plugins/worlds/empty_environment.sdf
@@ -38,8 +38,15 @@
 
     <plugin
       filename="ignition-gazebo-buoyancy-system"
-      name="ignition::gazebo::systems::Buoyancy">
-      <uniform_fluid_density>1025</uniform_fluid_density>
+      name="ignition::gazebo::systems::Buoyancy">        
+      <graded_buoyancy>
+        <default_density>1025</default_density>
+        <density_change>
+          <above_depth>0.5</above_depth>
+          <density>1.125</density>
+        </density_change>
+      </graded_buoyancy>
+      <!-- <uniform_fluid_density>1025</uniform_fluid_density> -->
     </plugin>
 
     <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied


### PR DESCRIPTION
This PR modifies WorldCommPlugin to allow correct formulation of AHRS topics when a vehicle is spawned using the a LRAUVInit message. 

The resulting AHRS topics take the form:
`/<vehicle_name>/ahrs/imu`, and 
`/<vehicle_name>/ahrs/magnetometer`

The PR also modifies `empty_environment.sdf ` to include graded buoyancy.