### PR TITLE
Hoist ign-sensors IMU and magnetometer plugins to world SDFs

### DIFF
--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -169,14 +169,12 @@
             </z>
           </angular_velocity>
           <topic>/tethys/ahrs/imu</topic>
-          <plugin filename="ignition-gazebo-imu-system"
-                  name="ignition::gazebo::systems::Imu"/>
         </sensor>
         <!--Magnetometer in a Sparton AHRS-M2 -->
         <sensor
             element_id="base_link"
             action="add"
-            name="ahrs_magnetometer"
+            name="sparton_ahrs_m2_magnetometer"
             type="magnetometer">
           <always_on>1</always_on>
           <update_rate>10</update_rate>
@@ -187,8 +185,6 @@
           -->
           <pose degrees="true">0 0 0 180 0 180</pose>
           <topic>/tethys/ahrs/magnetometer</topic>
-          <plugin filename="ignition-gazebo-magnetometer-system"
-                  name="ignition::gazebo::systems::Magnetometer"/>
         </sensor>
       </experimental:params>
       <!-- Joint controllers -->

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys.sdf
@@ -33,6 +33,14 @@
     </plugin>
 
     <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102-->

--- a/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
+++ b/lrauv_ignition_plugins/worlds/buoyant_tethys_at_depth.sdf
@@ -39,6 +39,14 @@
     </plugin>
 
     <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102-->

--- a/lrauv_ignition_plugins/worlds/empty_environment.sdf
+++ b/lrauv_ignition_plugins/worlds/empty_environment.sdf
@@ -37,6 +37,14 @@
     </plugin>
 
     <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <uniform_fluid_density>1025</uniform_fluid_density>

--- a/lrauv_ignition_plugins/worlds/multi_lrauv.sdf
+++ b/lrauv_ignition_plugins/worlds/multi_lrauv.sdf
@@ -31,6 +31,14 @@
     </plugin>
 
     <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <uniform_fluid_density>1025</uniform_fluid_density>

--- a/lrauv_ignition_plugins/worlds/star_world.sdf
+++ b/lrauv_ignition_plugins/worlds/star_world.sdf
@@ -31,6 +31,14 @@
     </plugin>
 
     <plugin
+      filename="ignition-gazebo-imu-system"
+      name="ignition::gazebo::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="ignition::gazebo::systems::Magnetometer">
+    </plugin>
+    <plugin
       filename="ignition-gazebo-buoyancy-system"
       name="ignition::gazebo::systems::Buoyancy">
       <uniform_fluid_density>1025</uniform_fluid_density>


### PR DESCRIPTION
System plugins for IMU and magnetometer sensors are scene-wide plugins.
