### PR TITLE
Separates the range bearing messages into two separate entities. 

### DIFF
--- a/lrauv_description/models/tethys/model.sdf.in
+++ b/lrauv_description/models/tethys/model.sdf.in
@@ -281,7 +281,33 @@
       </collision>
     </link>
 
+    <link name="acoustic_transponder">
+      <!-- TODO: Determine location of buoyancy engine -->
+      <pose degrees="true">0.137 0 0 0 0 180</pose>
+      <inertial>
+        <pose>0 0 0 0 0 0</pose>
+        <mass>0.01</mass>
+        <inertia>
+          <ixx>0.000143971303</ixx>
+          <ixy>0.000000000008</ixy>
+          <ixz>-0.000000000224</ixz>
+          <iyy>0.000140915448</iyy>
+          <iyz>-0.000025236433</iyz>
+          <izz>0.000033571862</izz>
+        </inertia>
+      </inertial>
+      <collision name="acoustic_transponder_col">
+        @neutral_buoyancy
+      </collision>
+    </link>
+
     <!-- Joints -->
+    <joint name="acoustic_transponder_joint" type="fixed">
+      <pose>0 0 0 0 0 0</pose>
+      <parent>base_link</parent>
+      <child>acoustic_transponder</child>
+      <namespace>tethys</namespace>
+    </joint>
     <joint name="buoyancy_engine_joint" type="fixed">
       <pose>0 0 0 0 0 0</pose>
       <parent>base_link</parent>

--- a/lrauv_description/models/tethys/model.sdf.in
+++ b/lrauv_description/models/tethys/model.sdf.in
@@ -283,7 +283,7 @@
 
     <link name="acoustic_transponder">
       <!-- TODO: Determine location of buoyancy engine -->
-      <pose degrees="true">0.137 0 0 0 0 180</pose>
+      <pose degrees="true">0 0 0 0 0 180</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>
         <mass>0.01</mass>

--- a/lrauv_description/models/tethys/model.sdf.in
+++ b/lrauv_description/models/tethys/model.sdf.in
@@ -282,7 +282,7 @@
     </link>
 
     <link name="acoustic_transponder">
-      <!-- TODO: Determine location of buoyancy engine -->
+      <!-- This link creates an ENU reference frame-->
       <pose degrees="true">0 0 0 0 0 180</pose>
       <inertial>
         <pose>0 0 0 0 0 0</pose>

--- a/lrauv_description/models/tethys_equipped/model.sdf
+++ b/lrauv_description/models/tethys_equipped/model.sdf
@@ -213,7 +213,7 @@
         <address>1</address>
         <model_plugin_file>simpleacousticmodel</model_plugin_file>
         <model_name>tethys::SimpleAcousticModel</model_name>
-        <link_name>base_link</link_name>
+        <link_name>acoustic_transponder</link_name>
         <max_range>2500</max_range>
         <speed_of_sound>1500</speed_of_sound>
       </plugin>
@@ -224,7 +224,7 @@
         <address>1</address>
         <processing_delay>0.3</processing_delay>
         <speed_of_sound>1500</speed_of_sound>
-        <link_name>base_link</link_name>
+        <link_name>acoustic_transponder</link_name>
         <namespace>tethys</namespace>
       </plugin>
 

--- a/lrauv_description/scripts/description_generator.py
+++ b/lrauv_description/scripts/description_generator.py
@@ -123,7 +123,7 @@ def generate_model(template_path, output_path):
         # Only these links get here. Checking to be safe because the script
         # isn't generic enough yet.
         link_name = link_tag.get("name")
-        assert link_name == "base_link" or link_name == "battery" or link_name == "drop_weight", link_name
+        assert link_name == "base_link" or link_name == "battery" or link_name == "drop_weight" or link_name == "acoustic_transponder", link_name
 
         # Get various tags used to calculate moments
         inertial_tag = link_tag.find(".inertial")

--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -261,6 +261,7 @@ if(BUILD_TESTING)
 
   # Tests
   foreach(TEST_TARGET
+    test_acoustic_comms_orientation
     test_buoyancy_action
     test_controller
     test_drop_weight

--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -288,6 +288,8 @@ if(BUILD_TESTING)
       lrauv_command
       lrauv_init
       lrauv_state
+      lrauv_range_bearing_request
+      lrauv_range_bearing_response
     )
     include_directories(${CMAKE_CURRENT_BINARY_DIR})
     gtest_discover_tests(${TEST_TARGET})

--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -175,6 +175,7 @@ add_lrauv_plugin(RangeBearingPlugin
   PROTO
     lrauv_range_bearing_request
     lrauv_range_bearing_response
+    lrauv_range_bearing_response_internal
     lrauv_acoustic_message)
 add_lrauv_plugin(ReferenceAxis GUI RENDERING)
 add_lrauv_plugin(ScienceSensorsSystem

--- a/lrauv_ignition_plugins/proto/CMakeLists.txt
+++ b/lrauv_ignition_plugins/proto/CMakeLists.txt
@@ -28,6 +28,7 @@ add_lrauv_message(lrauv_init)
 add_lrauv_message(lrauv_internal_comms)
 add_lrauv_message(lrauv_range_bearing_request)
 add_lrauv_message(lrauv_range_bearing_response)
+add_lrauv_message(lrauv_range_bearing_response_internal)
 add_lrauv_message(lrauv_state)
 
 install(

--- a/lrauv_ignition_plugins/proto/lrauv_range_bearing_response.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_range_bearing_response.proto
@@ -33,8 +33,8 @@ message LRAUVRangeBearingResponse
   /// \brief Request ID. Each request ID must be unique.
   uint32 req_id = 1;
 
-  /// \brief Bearing in terms of (r, theta, phi). This is based on ground truth
-  /// and not calculated using time-of-flight
+  /// \brief Bearing in terms of (r, elevation, azimuth). This is based
+  /// on ground truth and not calculated using time-of-flight
   ignition.msgs.Vector3d bearing = 2;
 
   /// \brief Time-Of-Flight reading. This is good for studying errors arising

--- a/lrauv_ignition_plugins/proto/lrauv_range_bearing_response.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_range_bearing_response.proto
@@ -33,11 +33,16 @@ message LRAUVRangeBearingResponse
   /// \brief Request ID. Each request ID must be unique.
   uint32 req_id = 1;
 
-  /// \brief Bearing in terms of (r, elevation, azimuth). This is based
-  /// on ground truth and not calculated using time-of-flight
-  ignition.msgs.Vector3d bearing = 2;
+  /// \brief Range in terms of ground truth meters.
+  double ground_truth_range = 2;
+
+  /// \brief elevation in radians
+  double elevation = 3;
+
+  /// \brief azimuth in radians
+  double azimuth = 4;
 
   /// \brief Time-Of-Flight reading. This is good for studying errors arising
   /// due to movement. But at high dt this may be prone to error.
-  double range = 3;
+  double range = 5;
 }

--- a/lrauv_ignition_plugins/proto/lrauv_range_bearing_response_internal.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_range_bearing_response_internal.proto
@@ -27,13 +27,16 @@
 
  import "ignition/msgs/vector3d.proto";
 
- /// \brief This protobuf is used internally by the RangeBearing plugin.
+ /// \brief This protobuf is used internally by the RangeBearing plugin. When a
+ /// transponder receives a range bearing request, it will send a response with
+ /// this payload on the acoustic channel.
  message LRAUVRangeBearingResponseInternal
  {
    /// \brief Request ID. Each request ID must be unique.
    uint32 req_id = 1;
 
-   /// \brief Position of the responding craft
+   /// \brief Position of the responding craft. This is derived from the ground
+   /// truth to keep things simple.
    ignition.msgs.Vector3d position = 2;
 
    /// \brief Time-Of-Flight reading. This is good for studying errors arising

--- a/lrauv_ignition_plugins/proto/lrauv_range_bearing_response_internal.proto
+++ b/lrauv_ignition_plugins/proto/lrauv_range_bearing_response_internal.proto
@@ -13,30 +13,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-*/
+ */
 
 /*
  * Development of this module has been funded by the Monterey Bay Aquarium
  * Research Institute (MBARI) and the David and Lucile Packard Foundation
  */
 
-#include "helper/LrauvCommsFixture.hh"
-#include "helper/LrauvRangeBearingClient.hh"
+ syntax = "proto3";
+ package lrauv_ignition_plugins.msgs;
+ option java_package = "lrauv_ignition_plugins.msgs";
+ option java_outer_classname = "LRAUVRangeBearingResponse";
 
-using namespace lrauv_ignition_plugins;
+ import "ignition/msgs/vector3d.proto";
 
-TEST_F(LrauvCommsFixture, TestRangingAccuracy)
-{
-  /// Needs to have the server call configure on the plugin before requesting.
-  this->fixture->Server()->Run(true, 100, false);
-  this->fixture->Server()->Run(false, 2000, false);
+ /// \brief This protobuf is used internally by the RangeBearing plugin.
+ message LRAUVRangeBearingResponseInternal
+ {
+   /// \brief Request ID. Each request ID must be unique.
+   uint32 req_id = 1;
 
-  RangeBearingClient client("box1");
-  auto result = client.RequestRange(2);
+   /// \brief Position of the responding craft
+   ignition.msgs.Vector3d position = 2;
 
-  EXPECT_EQ(result.req_id(), 2);
-  EXPECT_NEAR(result.range(), 20, 0.5);
-  EXPECT_NEAR(result.ground_truth_range(), 20, 1e-3);
-  EXPECT_NEAR(result.elevation(), 1.57, 1e-2);
-  EXPECT_NEAR(result.azimuth(), 1.57, 1e-2);
-}
+   /// \brief Time-Of-Flight reading. This is good for studying errors arising
+   /// due to movement. But at high dt this may be prone to error.
+   double range = 3;
+ }

--- a/lrauv_ignition_plugins/src/RangeBearingPlugin.cc
+++ b/lrauv_ignition_plugins/src/RangeBearingPlugin.cc
@@ -305,12 +305,12 @@ void RangeBearingPlugin::PreUpdate(
   this->dataPtr->timeNow = std::chrono::steady_clock::time_point{
     _info.simTime};
 
-  // Iterate through queue to identify acoustic messages 
+  // Iterate through queue to identify acoustic messages
   // that are ready to be responded to. This part implements the 300ms delay
   // that the transponder has.
   while(
     !this->dataPtr->messageQueue.empty()
-    && (this->dataPtr->messageQueue.front().timeOfReception 
+    && (this->dataPtr->messageQueue.front().timeOfReception
       + this->dataPtr->processingDelay) <= this->dataPtr->timeNow)
   {
     // Handles incoming messages

--- a/lrauv_ignition_plugins/test/helper/LrauvRangeBearingClient.hh
+++ b/lrauv_ignition_plugins/test/helper/LrauvRangeBearingClient.hh
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Development of this module has been funded by the Monterey Bay Aquarium
+ * Research Institute (MBARI) and the David and Lucile Packard Foundation
+ */
+
+#ifndef LRAUV_IGNITION_PLUGINS_TEST_HELPER_LRAUVRANGEBEARINGCLIENT_HH_
+#define LRAUV_IGNITION_PLUGINS_TEST_HELPER_LRAUVRANGEBEARINGCLIENT_HH_
+#include <ignition/transport.hh>
+#include <condition_variable>
+#include <mutex>
+
+#include "lrauv_range_bearing_request.pb.h"
+#include "lrauv_range_bearing_response.pb.h"
+
+using namespace lrauv_ignition_plugins;
+
+namespace lrauv_ignition_plugins {
+  class RangeBearingClient
+  {
+
+  public: RangeBearingClient(std::string address) :
+    request_counter(2)
+  {
+    this->pub = this->node.Advertise<msgs::LRAUVRangeBearingRequest>(
+      "/"+address+"/range_bearing/requests");
+    this->node.Subscribe("/"+address+"/range_bearing/responses",
+      &RangeBearingClient::onCallback,
+      this
+    );
+  }
+
+  public: msgs::LRAUVRangeBearingResponse RequestRange(uint32_t address)
+  {
+    msgs::LRAUVRangeBearingRequest req;
+    req.set_to(address);
+    req.set_req_id(this->request_counter);
+
+    this->received = false;
+
+    this->pub.Publish(req);
+
+    igndbg << "Published request" << "\n";
+
+    std::unique_lock<std::mutex> lk(this->mtx);
+    cv.wait(lk, [this]{return this->received;});
+
+    this->request_counter++;
+
+    return this->lastResponse;
+  }
+
+  public: void onCallback(const msgs::LRAUVRangeBearingResponse& resp)
+  {
+    igndbg << "Received message\n";
+    if(resp.req_id() == this->request_counter)
+    {
+      {
+        std::lock_guard<std::mutex> lk(this->mtx);
+        this->lastResponse = resp;
+        this->received = true;
+      }
+      cv.notify_all();
+    }
+  }
+
+  private: ignition::transport::Node node;
+
+  private: ignition::transport::Node::Publisher pub;
+
+  private: uint32_t request_counter;
+
+  private: std::mutex mtx;
+
+  private: std::condition_variable cv;
+
+  private: msgs::LRAUVRangeBearingResponse lastResponse;
+
+  private: bool received;
+};
+}
+#endif

--- a/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
+++ b/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
@@ -49,16 +49,29 @@ TEST_F(LrauvTestCommsOrientation, CheckCommsOrientation)
 
   RangeBearingClient client("tethys");
   auto box1 = client.RequestRange(2);
-  //auto box2 = client.RequestRange(3);
- // auto box3 = client.RequestRange(4);
+  auto box2 = client.RequestRange(3);
+  auto box3 = client.RequestRange(4);
 
-  //EXPECT_NEAR(box1.bearing().x(), 10, 1);
-  //EXPECT_NEAR(box2.bearing().x(), 10, 1);
-  //EXPECT_NEAR(box3.bearing().x(), 10, 1);
-  // Range bearing in ENU frame
-  // Box1 is directly infront of the vehicle hence the bearing is (10,0,0)
-  // Bearing 
+  // Range bearing in FSK frame with elevation being calculated by
+  // Box2 cartesian coordinates in vehicle ENU local frame (10, 0, 0)
+  // Note convention is (range, elevation, azimuth)
+  // Box1 is directly infront of the vehicle hence the bearing is (10, 0, 0)
   EXPECT_NEAR(box1.bearing().x(), 10, 1e-3);
   EXPECT_NEAR(box1.bearing().y(), 0, 1e-3);
   EXPECT_NEAR(box1.bearing().z(), 0, 1e-3);
+
+  // Range bearing in FSK frame
+  // Box2 cartesian coordinates in vehicle ENU local frame (0, -10, 0)
+  // ?? Seems weird
+  // Box2 is to the right of the vehicle hence the bearing is (10, 0, 1.57)
+  EXPECT_NEAR(box2.bearing().x(), 10, 1e-3);
+  EXPECT_NEAR(box2.bearing().y(), 0, 1e-3);
+  EXPECT_NEAR(box2.bearing().z(), 1.57, 1e-3);
+
+  // Range bearing in FSK frame
+  // Box3 cartesian coordinates in vehicle ENU local frame (0, 0, -10)
+  // Box3 is directly below the vehicle hence the bearing is (10, 1.57, 0)
+  EXPECT_NEAR(box3.bearing().x(), 10, 1e-3);
+  EXPECT_NEAR(box3.bearing().y(), 1.57, 1e-3);
+  EXPECT_NEAR(box3.bearing().z(), 0, 1e-3);
 }

--- a/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
+++ b/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
@@ -56,22 +56,22 @@ TEST_F(LrauvTestCommsOrientation, CheckCommsOrientation)
   // Box2 cartesian coordinates in vehicle ENU local frame (10, 0, 0)
   // Note convention is (range, elevation, azimuth)
   // Box1 is directly infront of the vehicle hence the bearing is (10, 0, 0)
-  EXPECT_NEAR(box1.bearing().x(), 10, 1e-3);
-  EXPECT_NEAR(box1.bearing().y(), 0, 1e-3);
-  EXPECT_NEAR(box1.bearing().z(), 0, 1e-3);
+  EXPECT_NEAR(box1.ground_truth_range(), 10, 1e-3);
+  EXPECT_NEAR(box1.elevation(), 0, 1e-3);
+  EXPECT_NEAR(box1.azimuth(), 0, 1e-3);
 
   // Range bearing in FSK frame
   // Box2 cartesian coordinates in vehicle ENU local frame (0, -10, 0)
   // ?? Seems weird
   // Box2 is to the right of the vehicle hence the bearing is (10, 0, 1.57)
-  EXPECT_NEAR(box2.bearing().x(), 10, 1e-3);
-  EXPECT_NEAR(box2.bearing().y(), 0, 1e-3);
-  EXPECT_NEAR(box2.bearing().z(), 1.57, 1e-3);
+  EXPECT_NEAR(box2.ground_truth_range(), 10, 1e-3);
+  EXPECT_NEAR(box2.elevation(), 0, 1e-3);
+  EXPECT_NEAR(box2.azimuth(), 1.57, 1e-3);
 
   // Range bearing in FSK frame
   // Box3 cartesian coordinates in vehicle ENU local frame (0, 0, -10)
   // Box3 is directly below the vehicle hence the bearing is (10, 1.57, 0)
-  EXPECT_NEAR(box3.bearing().x(), 10, 1e-3);
-  EXPECT_NEAR(box3.bearing().y(), 1.57, 1e-3);
-  EXPECT_NEAR(box3.bearing().z(), 0, 1e-3);
+  EXPECT_NEAR(box3.ground_truth_range(), 10, 1e-3);
+  EXPECT_NEAR(box3.elevation(), 1.57, 1e-3);
+  EXPECT_NEAR(box3.azimuth(), 0, 1e-3);
 }

--- a/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
+++ b/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021 Open Source Robotics Foundation
+ * Copyright (C) 2022 Open Source Robotics Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,6 +27,7 @@
 #include "lrauv_command.pb.h"
 
 #include <fstream>
+#include "helper/LrauvRangeBearingClient.hh"
 
 /// \brief Loads the tethys "tethys_acoustic_comms.sdf" world.
 /// This world has the robot start at a certain depth and 3 acoustic comms nodes
@@ -35,12 +36,29 @@ class LrauvTestCommsOrientation : public LrauvTestFixtureBase
   /// Documentation inherited
   protected: void SetUp() override
   {
-    LrauvTestFixtureBase::SetUp("tethys_acoustic_comms.sdf");
+    LrauvTestFixtureBase::SetUp("tethys_acoustic_comms_test.sdf");
   }
 };
 
 //////////////////////////////////////////////////
 TEST_F(LrauvTestCommsOrientation, CheckCommsOrientation)
 {
+  /// Needs to have the server call configure on the plugin before requesting.
+  this->fixture->Server()->Run(true, 100, false);
+  this->fixture->Server()->Run(false, 10000, false);
 
+  RangeBearingClient client("tethys");
+  auto box1 = client.RequestRange(2);
+  //auto box2 = client.RequestRange(3);
+ // auto box3 = client.RequestRange(4);
+
+  //EXPECT_NEAR(box1.bearing().x(), 10, 1);
+  //EXPECT_NEAR(box2.bearing().x(), 10, 1);
+  //EXPECT_NEAR(box3.bearing().x(), 10, 1);
+  // Range bearing in ENU frame
+  // Box1 is directly infront of the vehicle hence the bearing is (10,0,0)
+  // Bearing 
+  EXPECT_NEAR(box1.bearing().x(), 10, 1e-3);
+  EXPECT_NEAR(box1.bearing().y(), 0, 1e-3);
+  EXPECT_NEAR(box1.bearing().z(), 0, 1e-3);
 }

--- a/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
+++ b/lrauv_ignition_plugins/test/test_acoustic_comms_orientation.cc
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2021 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Development of this module has been funded by the Monterey Bay Aquarium
+ * Research Institute (MBARI) and the David and Lucile Packard Foundation
+ */
+
+#include <chrono>
+#include <gtest/gtest.h>
+
+#include "helper/LrauvTestFixture.hh"
+#include "lrauv_command.pb.h"
+
+#include <fstream>
+
+/// \brief Loads the tethys "tethys_acoustic_comms.sdf" world.
+/// This world has the robot start at a certain depth and 3 acoustic comms nodes
+class LrauvTestCommsOrientation : public LrauvTestFixtureBase
+{
+  /// Documentation inherited
+  protected: void SetUp() override
+  {
+    LrauvTestFixtureBase::SetUp("tethys_acoustic_comms.sdf");
+  }
+};
+
+//////////////////////////////////////////////////
+TEST_F(LrauvTestCommsOrientation, CheckCommsOrientation)
+{
+
+}

--- a/lrauv_ignition_plugins/test/test_range_bearing.cc
+++ b/lrauv_ignition_plugins/test/test_range_bearing.cc
@@ -21,80 +21,16 @@
  */
 
 #include "helper/LrauvCommsFixture.hh"
-#include "lrauv_range_bearing_request.pb.h"
-#include "lrauv_range_bearing_response.pb.h"
+#include "helper/LrauvRangeBearingClient.hh"
 
 using namespace lrauv_ignition_plugins;
-
-class RangeBearingClient
-{
-
-public: RangeBearingClient(std::string address) :
-  request_counter(2)
-{
-  this->pub = this->node.Advertise<msgs::LRAUVRangeBearingRequest>(
-    "/"+address+"/range_bearing/requests");
-  this->node.Subscribe("/"+address+"/range_bearing/responses",
-    &RangeBearingClient::onCallback,
-    this
-  );
-}
-
-public: msgs::LRAUVRangeBearingResponse RequestRange(uint32_t address)
-{
-  msgs::LRAUVRangeBearingRequest req;
-  req.set_to(address);
-  req.set_req_id(this->request_counter);
-
-  this->received = false;
-
-  this->pub.Publish(req);
-
-  igndbg << "Published request" << "\n";
-
-  std::unique_lock<std::mutex> lk(this->mtx);
-  cv.wait(lk, [this]{return this->received;});
-
-  this->request_counter++;
-
-  return this->lastResponse;
-}
-
-public: void onCallback(const msgs::LRAUVRangeBearingResponse& resp)
-{
-  igndbg << "Received message\n";
-  if(resp.req_id() == this->request_counter)
-  {
-    {
-      std::lock_guard<std::mutex> lk(this->mtx);
-      this->lastResponse = resp;
-      this->received = true;
-    }
-    cv.notify_all();
-  }
-}
-
-private: ignition::transport::Node node;
-
-private: ignition::transport::Node::Publisher pub;
-
-private: uint32_t request_counter;
-
-private: std::mutex mtx;
-
-private: std::condition_variable cv;
-
-private: msgs::LRAUVRangeBearingResponse lastResponse;
-
-private: bool received;
-};
 
 TEST_F(LrauvCommsFixture, TestRangingAccuracy)
 {
   /// Needs to have the server call configure on the plugin before requesting.
   this->fixture->Server()->Run(true, 100, false);
   this->fixture->Server()->Run(false, 2000, false);
-  
+
   RangeBearingClient client("box1");
   auto result = client.RequestRange(2);
 

--- a/lrauv_ignition_plugins/worlds/tethys_acoustic_comms_test.sdf
+++ b/lrauv_ignition_plugins/worlds/tethys_acoustic_comms_test.sdf
@@ -510,7 +510,7 @@
         <processing_delay>0.3</processing_delay>
         <speed_of_sound>1500</speed_of_sound>
         <link_name>base_link</link_name>
-        <namespace>box2</namespace>
+        <namespace>box3</namespace>
       </plugin>
     </model>
 

--- a/lrauv_ignition_plugins/worlds/tethys_acoustic_comms_test.sdf
+++ b/lrauv_ignition_plugins/worlds/tethys_acoustic_comms_test.sdf
@@ -1,0 +1,518 @@
+<?xml version="1.0" ?>
+<!--
+  Development of this module has been funded by the Monterey Bay Aquarium
+  Research Institute (MBARI) and the David and Lucile Packard Foundation
+-->
+
+<!--
+  This file is essentially identical to buoyant_tethys, except the vehicle
+  starts at a depth of -10m instead of 0m. This is for tests that require the
+  vehicle to be fully submerged.
+-->
+<sdf version="1.6">
+  <world name="buoyant_tethys">
+    <scene>
+      <!-- For turquoise ambient to match particle effect -->
+      <ambient>0.0 1.0 1.0</ambient>
+      <!-- For default gray ambient -->
+      <!--background>0.8 0.8 0.8</background-->
+      <background>0.0 0.7 0.8</background>
+
+      <grid>false</grid>
+    </scene>
+
+    <physics name="1ms" type="dart">
+      <max_step_size>0.02</max_step_size>
+      <real_time_factor>0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="ignition::gazebo::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="ignition::gazebo::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="ignition::gazebo::systems::SceneBroadcaster">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-buoyancy-system"
+      name="ignition::gazebo::systems::Buoyancy">
+      <!-- TODO: fix behaviour near surface, see https://github.com/osrf/lrauv/issues/102-->
+        <graded_buoyancy>
+        <default_density>1025</default_density>
+        <density_change>
+          <above_depth>0.5</above_depth>
+          <density>1.125</density>
+        </density_change>
+      </graded_buoyancy>
+    </plugin>
+
+    <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <!--<plugin
+      filename="ignition-gazebo-particle-emitter2-system"
+      name="ignition::gazebo::systems::ParticleEmitter2">
+    </plugin>-->
+
+    <!-- Uncomment for time analysis -->
+    <!--plugin
+      filename="TimeAnalysisPlugin"
+      name="tethys::TimeAnalysisPlugin">
+    </plugin-->
+
+    <!-- Spawn by default in a location with science data in csv -->
+    <spherical_coordinates>
+      <surface_model>EARTH_WGS84</surface_model>
+      <world_frame_orientation>ENU</world_frame_orientation>
+
+      <!-- For 2003080103_mb_l3_las.csv -->
+      <latitude_deg>35.5999984741211</latitude_deg>
+      <longitude_deg>-121.779998779297</longitude_deg>
+
+      <!-- For 2003080103_mb_l3_las_1x1km.csv -->
+      <!--latitude_deg>36.8024781413352</latitude_deg>
+      <longitude_deg>-121.829647676843</longitude_deg-->
+
+      <!-- For simple_test.csv -->
+      <!--latitude_deg>0</latitude_deg>
+      <longitude_deg>0</longitude_deg-->
+
+      <elevation>0</elevation>
+      <heading_deg>0</heading_deg>
+    </spherical_coordinates>
+    <plugin
+      filename="ScienceSensorsSystem"
+      name="tethys::ScienceSensorsSystem">
+      <data_path>2003080103_mb_l3_las.csv</data_path>
+      <!--data_path>2003080103_mb_l3_las_1x1km.csv</data_path-->
+      <!--data_path>simple_test.csv</data_path-->
+    </plugin>
+
+    <gui fullscreen="0">
+
+      <!-- 3D scene -->
+      <plugin filename="MinimalScene" name="3D View">
+        <ignition-gui>
+          <title>3D View</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="string" key="state">docked</property>
+        </ignition-gui>
+
+        <engine>ogre2</engine>
+        <scene>scene</scene>
+        <ambient_light>0.4 0.4 0.4</ambient_light>
+        <background_color>0.8 0.8 0.8</background_color>
+        <!-- looking at robot -->
+        <camera_pose>4.5 0 4  0 0.45 3.14</camera_pose>
+        <!-- looking at all science data for 2003080103_mb_l3_las.csv -->
+        <!--camera_pose>-50000 -30000 250000 0 1.1 1.58</camera_pose-->
+        <camera_clip>
+          <!-- ortho view needs low near clip -->
+          <!-- but a very low near clip messes orbit's far clip ?! -->
+          <near>0.1</near>
+          <!-- See 3000 km away -->
+          <far>3000000</far>
+        </camera_clip>
+      </plugin>
+
+      <!-- Plugins that add functionality to the scene -->
+      <plugin filename="EntityContextMenuPlugin" name="Entity context menu">
+        <ignition-gui>
+          <property key="state" type="string">floating</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="GzSceneManager" name="Scene Manager">
+        <ignition-gui>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="InteractiveViewControl" name="Interactive view control">
+        <ignition-gui>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="CameraTracking" name="Camera Tracking">
+        <ignition-gui>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="MarkerManager" name="Marker manager">
+        <ignition-gui>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+        <warn_on_action_failure>false</warn_on_action_failure>
+      </plugin>
+      <plugin filename="SelectEntities" name="Select Entities">
+        <ignition-gui>
+          <anchors target="Select entities">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="VisualizationCapabilities" name="Visualization Capabilities">
+        <ignition-gui>
+          <anchors target="Select entities">
+            <line own="right" target="right"/>
+            <line own="top" target="top"/>
+          </anchors>
+          <property key="resizable" type="bool">false</property>
+          <property key="width" type="double">5</property>
+          <property key="height" type="double">5</property>
+          <property key="state" type="string">floating</property>
+          <property key="showTitleBar" type="bool">false</property>
+        </ignition-gui>
+      </plugin>
+
+      <!-- World control -->
+      <plugin filename="WorldControl" name="World control">
+        <ignition-gui>
+          <title>World control</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">72</property>
+          <property type="double" key="width">121</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="left" target="left"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <play_pause>true</play_pause>
+        <step>true</step>
+        <start_paused>true</start_paused>
+      </plugin>
+
+      <!-- World statistics -->
+      <plugin filename="WorldStats" name="World stats">
+        <ignition-gui>
+          <title>World stats</title>
+          <property type="bool" key="showTitleBar">false</property>
+          <property type="bool" key="resizable">false</property>
+          <property type="double" key="height">110</property>
+          <property type="double" key="width">290</property>
+          <property type="double" key="z">1</property>
+
+          <property type="string" key="state">floating</property>
+          <anchors target="3D View">
+            <line own="right" target="right"/>
+            <line own="bottom" target="bottom"/>
+          </anchors>
+        </ignition-gui>
+
+        <sim_time>true</sim_time>
+        <real_time>true</real_time>
+        <real_time_factor>true</real_time_factor>
+        <iterations>true</iterations>
+      </plugin>
+
+      <plugin filename="Plot3D" name="Plot 3D">
+        <ignition-gui>
+          <title>Plot Tethys 3D path</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+        <entity_name>tethys</entity_name>
+        <color>0 0 1</color>
+        <maximum_points>10000</maximum_points>
+        <minimum_distance>0.5</minimum_distance>
+      </plugin>
+      <plugin filename="ComponentInspector" name="Component Inspector">
+        <ignition-gui>
+          <title>Inspector</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="PointCloud" name="Visualize science data">
+        <ignition-gui>
+          <title>Visualize science data</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="ViewAngle" name="Camera controls">
+        <ignition-gui>
+          <title>Camera controls</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="GridConfig" name="Grid config">
+        <ignition-gui>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+        <insert>
+          <!-- 300 km x 300 km -->
+          <cell_count>6</cell_count>
+          <vertical_cell_count>0</vertical_cell_count>
+          <!-- 50 km -->
+          <cell_length>50000</cell_length>
+          <pose>0 100000 0  0 0 0.32</pose>
+          <color>0 1 0 1</color>
+        </insert>
+        <insert>
+          <!-- 0.1 km x 0.1 km -->
+          <cell_count>100</cell_count>
+          <vertical_cell_count>0</vertical_cell_count>
+          <!-- 1 m -->
+          <cell_length>1</cell_length>
+          <pose>0 0 0  0 0 0</pose>
+          <color>0.5 0.5 0.5 1</color>
+        </insert>
+      </plugin>
+      <plugin filename="ControlPanelPlugin" name="Tethys Controls">
+        <ignition-gui>
+          <title>Tethys controls</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+      </plugin>
+      <plugin filename="ReferenceAxis" name="Reference axis">
+        <ignition-gui>
+          <title>Reference axis</title>
+          <property type="string" key="state">docked_collapsed</property>
+        </ignition-gui>
+        <fsk>tethys</fsk>
+      </plugin>
+    </gui>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+
+    <!-- This invisible plane helps with orbiting the camera, especially at large scales -->
+    <model name="horizontal_plane">
+      <static>true</static>
+      <link name="link">
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <!-- 300 km x 300 km -->
+              <size>300000 300000</size>
+            </plane>
+          </geometry>
+          <transparency>1.0</transparency>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Uncomment for particle effect
+      Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <!--include>
+      <pose>-5 0 0 0 0 0</pose>
+      <uri>turbidity_generator</uri>
+    </include-->
+
+    <include>
+      <pose>0 0 -10 0 0 0</pose>
+      <uri>tethys_equipped</uri>
+    </include>
+
+
+    <model name="commsLink1">
+      <static>true</static>
+      <pose>0 10 -10 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1000</mass>
+          <inertia>
+            <ixx>86.289</ixx>
+            <iyy>86.289</iyy>
+            <izz>86.289</izz>
+          </inertia>
+        </inertial>
+        <visual name="base_link_vis">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_link_coll">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <plugin
+        filename="AcousticCommsPlugin"
+        name="tethys::AcousticCommsPlugin">
+        <address>2</address>
+        <model_plugin_file>simpleacousticmodel</model_plugin_file>
+        <model_name>tethys::SimpleAcousticModel</model_name>
+        <link_name>base_link</link_name>
+        <max_range>2500</max_range>
+        <speed_of_sound>1500</speed_of_sound>
+        <timestep>0.000001</timestep>
+      </plugin>
+      <plugin
+        filename="RangeBearingPlugin"
+        name="tethys::RangeBearingPlugin">
+        <address>2</address>
+        <processing_delay>0.3</processing_delay>
+        <speed_of_sound>1500</speed_of_sound>
+        <link_name>base_link</link_name>
+        <namespace>box1</namespace>
+      </plugin>
+    </model>
+
+    <model name="commsLink2">
+      <static>true</static>
+      <pose>10 0 -10 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1000</mass>
+          <inertia>
+            <ixx>86.289</ixx>
+            <iyy>86.289</iyy>
+            <izz>86.289</izz>
+          </inertia>
+        </inertial>
+        <visual name="base_link_vis">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_link_coll">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <plugin
+        filename="AcousticCommsPlugin"
+        name="tethys::AcousticCommsPlugin">
+        <address>3</address>
+        <model_plugin_file>simpleacousticmodel</model_plugin_file>
+        <model_name>tethys::SimpleAcousticModel</model_name>
+        <link_name>base_link</link_name>
+        <max_range>2500</max_range>
+        <speed_of_sound>1500</speed_of_sound>
+        <timestep>0.000001</timestep>
+      </plugin>
+      <plugin
+        filename="RangeBearingPlugin"
+        name="tethys::RangeBearingPlugin">
+        <address>3</address>
+        <processing_delay>0.3</processing_delay>
+        <speed_of_sound>1500</speed_of_sound>
+        <link_name>base_link</link_name>
+        <namespace>box2</namespace>
+      </plugin>
+    </model>
+
+    <model name="commsLink3">
+      <static>true</static>
+      <pose>0 0 -20 0 0 0</pose>
+      <link name="base_link">
+        <inertial>
+          <mass>1000</mass>
+          <inertia>
+            <ixx>86.289</ixx>
+            <iyy>86.289</iyy>
+            <izz>86.289</izz>
+          </inertia>
+        </inertial>
+        <visual name="base_link_vis">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </visual>
+        <collision name="base_link_coll">
+          <geometry>
+            <box>
+              <size>1 1 1</size>
+            </box>
+          </geometry>
+        </collision>
+      </link>
+      <plugin
+        filename="AcousticCommsPlugin"
+        name="tethys::AcousticCommsPlugin">
+        <address>4</address>
+        <model_plugin_file>simpleacousticmodel</model_plugin_file>
+        <model_name>tethys::SimpleAcousticModel</model_name>
+        <link_name>base_link</link_name>
+        <max_range>2500</max_range>
+        <speed_of_sound>1500</speed_of_sound>
+        <timestep>0.000001</timestep>
+      </plugin>
+      <plugin
+        filename="RangeBearingPlugin"
+        name="tethys::RangeBearingPlugin">
+        <address>4</address>
+        <processing_delay>0.3</processing_delay>
+        <speed_of_sound>1500</speed_of_sound>
+        <link_name>base_link</link_name>
+        <namespace>box2</namespace>
+      </plugin>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
Previously we were using the same RangeBearing message for both external communication and internal communication. This leads to lots of confusion as we were using the same message in two different places. This PR also changes the public facing `LRAUVRangeBearingResponse` to stop using a vector to store the coordinates, but rather explicitly label the coordinates.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>