### PR TITLE
Fix test_range_bearing.cc

### DIFF
--- a/lrauv_ignition_plugins/test/test_range_bearing.cc
+++ b/lrauv_ignition_plugins/test/test_range_bearing.cc
@@ -37,6 +37,6 @@ TEST_F(LrauvCommsFixture, TestRangingAccuracy)
   EXPECT_EQ(result.req_id(), 2);
   EXPECT_NEAR(result.range(), 20, 0.5);
   EXPECT_NEAR(result.bearing().x(), 20, 1e-3);
-  EXPECT_NEAR(result.bearing().y(), 1.57, 1e-2);
-  EXPECT_NEAR(result.bearing().z(), 1.57, 1e-2);
+  EXPECT_NEAR(result.bearing().y(), 0., 1e-2);
+  EXPECT_NEAR(result.bearing().z(), -1.57, 1e-2);
 }


### PR DESCRIPTION
Follow-up after #174. Alternatively, we could drop this test, as it is redundant with `test_acoustic_comms_orientation.cc`.