### PR TITLE
Port package names in CMake to gz

### DIFF
--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -23,29 +23,28 @@ endif()
 find_package(gz-cmake3 REQUIRED)
 
 find_package(gz-sim7 REQUIRED COMPONENTS gui)
-set(IGN_GAZEBO_VER ${gz-sim7_VERSION_MAJOR})
+set(GZ_SIM_VER ${gz-sim7_VERSION_MAJOR})
 
 find_package(gz-gui7 REQUIRED)
-set(IGN_GUI_VER ${gz-gui7_VERSION_MAJOR})
+set(GZ_GUI_VER ${gz-gui7_VERSION_MAJOR})
 
 find_package(gz-rendering7 REQUIRED)
-set(IGN_RENDERING_VER ${gz-rendering7_VERSION_MAJOR})
+set(GZ_RENDERING_VER ${gz-rendering7_VERSION_MAJOR})
 
 find_package(gz-sensors7 REQUIRED)
-set(IGN_SENSORS_VER ${gz-sensors7_VERSION_MAJOR})
+set(GZ_SENSORS_VER ${gz-sensors7_VERSION_MAJOR})
 
 find_package(gz-msgs9 REQUIRED)
-set(IGN_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
-set(IGNITION_MSGS gz-msgs${IGN_MSGS_VER}::gz-msgs${IGN_MSGS_VER})
+set(GZ_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
 
 find_package(gz-plugin2 REQUIRED COMPONENTS register)
-set(IGN_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
+set(GZ_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 
 find_package(gz-utils2 REQUIRED)
-set(IGN_UTILS_VER ${gz-utils2_VERSION_MAJOR})
+set(GZ_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 
 find_package(gz-common5 REQUIRED COMPONENTS profiler)
-set(IGN_COMMON_VER ${gz-common5_VERSION_MAJOR})
+set(GZ_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 find_package (Eigen3 3.3 REQUIRED)
 
@@ -102,9 +101,9 @@ function(add_lrauv_plugin PLUGIN)
   set_property(TARGET ${PLUGIN} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${PLUGIN}
     PUBLIC
-      gz-common${IGN_COMMON_VER}::profiler
-      gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
-      gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
+      gz-common${GZ_COMMON_VER}::profiler
+      gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+      gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
     PRIVATE
       ${add_lrauv_plugin_PRIVATE_LINK_LIBS}
   )
@@ -127,7 +126,7 @@ function(add_lrauv_plugin PLUGIN)
       PUBLIC
         TINYXML2::TINYXML2
       PRIVATE
-        gz-gui${IGN_GUI_VER}::gz-gui${IGN_GUI_VER}
+        gz-gui${GZ_GUI_VER}::gz-gui${GZ_GUI_VER}
     )
 
     target_include_directories(${PLUGIN}
@@ -138,7 +137,7 @@ function(add_lrauv_plugin PLUGIN)
   if (add_lrauv_plugin_RENDERING)
     target_link_libraries(${PLUGIN}
       PRIVATE
-        gz-rendering${IGN_RENDERING_VER}::gz-rendering${IGN_RENDERING_VER}
+        gz-rendering${GZ_RENDERING_VER}::gz-rendering${GZ_RENDERING_VER}
     )
   endif()
 
@@ -171,7 +170,7 @@ add_lrauv_plugin(ReferenceAxis GUI RENDERING)
 add_lrauv_plugin(ScienceSensorsSystem
   PCL
   PRIVATE_LINK_LIBS
-    gz-sensors${IGN_SENSORS_VER}::gz-sensors${IGN_SENSORS_VER}
+    gz-sensors${GZ_SENSORS_VER}::gz-sensors${GZ_SENSORS_VER}
     ${PCL_LIBRARIES})
 add_lrauv_plugin(SpawnPanelPlugin GUI
   PROTO
@@ -212,7 +211,7 @@ foreach(EXAMPLE
   add_executable(${EXAMPLE_EXEC} example/${EXAMPLE}.cc)
   set_property(TARGET ${EXAMPLE_EXEC} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${EXAMPLE_EXEC} PRIVATE
-    gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
+    gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
     lrauv_acoustic_message lrauv_command lrauv_init lrauv_internal_comms
     lrauv_range_bearing_request lrauv_range_bearing_response lrauv_state)
 

--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -20,32 +20,32 @@ endif()
 
 #============================================================================
 # Find dependencies
-find_package(ignition-cmake3 REQUIRED)
+find_package(gz-cmake3 REQUIRED)
 
-find_package(ignition-gazebo7 REQUIRED COMPONENTS gui)
-set(IGN_GAZEBO_VER ${ignition-gazebo7_VERSION_MAJOR})
+find_package(gz-sim7 REQUIRED COMPONENTS gui)
+set(IGN_GAZEBO_VER ${gz-sim7_VERSION_MAJOR})
 
-find_package(ignition-gui7 REQUIRED)
-set(IGN_GUI_VER ${ignition-gui7_VERSION_MAJOR})
+find_package(gz-gui7 REQUIRED)
+set(IGN_GUI_VER ${gz-gui7_VERSION_MAJOR})
 
-find_package(ignition-rendering7 REQUIRED)
-set(IGN_RENDERING_VER ${ignition-rendering7_VERSION_MAJOR})
+find_package(gz-rendering7 REQUIRED)
+set(IGN_RENDERING_VER ${gz-rendering7_VERSION_MAJOR})
 
-find_package(ignition-sensors7 REQUIRED)
-set(IGN_SENSORS_VER ${ignition-sensors7_VERSION_MAJOR})
+find_package(gz-sensors7 REQUIRED)
+set(IGN_SENSORS_VER ${gz-sensors7_VERSION_MAJOR})
 
-find_package(ignition-msgs9 REQUIRED)
-set(IGN_MSGS_VER ${ignition-msgs9_VERSION_MAJOR})
-set(IGNITION_MSGS ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER})
+find_package(gz-msgs9 REQUIRED)
+set(IGN_MSGS_VER ${gz-msgs9_VERSION_MAJOR})
+set(IGNITION_MSGS gz-msgs${IGN_MSGS_VER}::gz-msgs${IGN_MSGS_VER})
 
-find_package(ignition-plugin2 REQUIRED COMPONENTS register)
-set(IGN_PLUGIN_VER ${ignition-plugin2_VERSION_MAJOR})
+find_package(gz-plugin2 REQUIRED COMPONENTS register)
+set(IGN_PLUGIN_VER ${gz-plugin2_VERSION_MAJOR})
 
-find_package(ignition-utils2 REQUIRED)
-set(IGN_UTILS_VER ${ignition-utils2_VERSION_MAJOR})
+find_package(gz-utils2 REQUIRED)
+set(IGN_UTILS_VER ${gz-utils2_VERSION_MAJOR})
 
-find_package(ignition-common5 REQUIRED COMPONENTS profiler)
-set(IGN_COMMON_VER ${ignition-common5_VERSION_MAJOR})
+find_package(gz-common5 REQUIRED COMPONENTS profiler)
+set(IGN_COMMON_VER ${gz-common5_VERSION_MAJOR})
 
 find_package (Eigen3 3.3 REQUIRED)
 
@@ -102,9 +102,9 @@ function(add_lrauv_plugin PLUGIN)
   set_property(TARGET ${PLUGIN} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${PLUGIN}
     PUBLIC
-      ignition-common${IGN_COMMON_VER}::profiler
-      ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
-      ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER}
+      gz-common${IGN_COMMON_VER}::profiler
+      gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
+      gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
     PRIVATE
       ${add_lrauv_plugin_PRIVATE_LINK_LIBS}
   )
@@ -127,7 +127,7 @@ function(add_lrauv_plugin PLUGIN)
       PUBLIC
         TINYXML2::TINYXML2
       PRIVATE
-        ignition-gui${IGN_GUI_VER}::ignition-gui${IGN_GUI_VER}
+        gz-gui${IGN_GUI_VER}::gz-gui${IGN_GUI_VER}
     )
 
     target_include_directories(${PLUGIN}
@@ -138,7 +138,7 @@ function(add_lrauv_plugin PLUGIN)
   if (add_lrauv_plugin_RENDERING)
     target_link_libraries(${PLUGIN}
       PRIVATE
-        ignition-rendering${IGN_RENDERING_VER}::ignition-rendering${IGN_RENDERING_VER}
+        gz-rendering${IGN_RENDERING_VER}::gz-rendering${IGN_RENDERING_VER}
     )
   endif()
 
@@ -171,7 +171,7 @@ add_lrauv_plugin(ReferenceAxis GUI RENDERING)
 add_lrauv_plugin(ScienceSensorsSystem
   PCL
   PRIVATE_LINK_LIBS
-    ignition-sensors${IGN_SENSORS_VER}::ignition-sensors${IGN_SENSORS_VER}
+    gz-sensors${IGN_SENSORS_VER}::gz-sensors${IGN_SENSORS_VER}
     ${PCL_LIBRARIES})
 add_lrauv_plugin(SpawnPanelPlugin GUI
   PROTO
@@ -212,7 +212,7 @@ foreach(EXAMPLE
   add_executable(${EXAMPLE_EXEC} example/${EXAMPLE}.cc)
   set_property(TARGET ${EXAMPLE_EXEC} PROPERTY CXX_STANDARD 17)
   target_link_libraries(${EXAMPLE_EXEC} PRIVATE
-    ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER}
+    gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
     lrauv_acoustic_message lrauv_command lrauv_init lrauv_internal_comms
     lrauv_range_bearing_request lrauv_range_bearing_response lrauv_state)
 

--- a/lrauv_ignition_plugins/proto/CMakeLists.txt
+++ b/lrauv_ignition_plugins/proto/CMakeLists.txt
@@ -9,13 +9,13 @@ function(add_lrauv_message MESSAGE)
   add_library(${MESSAGE} SHARED ${PROJECT_NAME}/${MESSAGE}.proto)
   target_link_libraries(${MESSAGE}
     protobuf::libprotobuf
-    ignition-msgs${IGN_MSGS_VER}::ignition-msgs${IGN_MSGS_VER})
+    gz-msgs${IGN_MSGS_VER}::gz-msgs${IGN_MSGS_VER})
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/proto)
   protobuf_generate(
     TARGET ${MESSAGE}
     LANGUAGE cpp
     IMPORT_DIRS
-      ${ignition-msgs${IGN_MSGS_VER}_INCLUDE_DIRS}
+      ${gz-msgs${IGN_MSGS_VER}_INCLUDE_DIRS}
       ${CMAKE_BINARY_DIR}/proto
     PROTOC_OUT_DIR ${CMAKE_BINARY_DIR}/proto
   )

--- a/lrauv_ignition_plugins/proto/CMakeLists.txt
+++ b/lrauv_ignition_plugins/proto/CMakeLists.txt
@@ -9,13 +9,13 @@ function(add_lrauv_message MESSAGE)
   add_library(${MESSAGE} SHARED ${PROJECT_NAME}/${MESSAGE}.proto)
   target_link_libraries(${MESSAGE}
     protobuf::libprotobuf
-    gz-msgs${IGN_MSGS_VER}::gz-msgs${IGN_MSGS_VER})
+    gz-msgs${GZ_MSGS_VER}::gz-msgs${GZ_MSGS_VER})
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/proto)
   protobuf_generate(
     TARGET ${MESSAGE}
     LANGUAGE cpp
     IMPORT_DIRS
-      ${gz-msgs${IGN_MSGS_VER}_INCLUDE_DIRS}
+      ${gz-msgs${GZ_MSGS_VER}_INCLUDE_DIRS}
       ${CMAKE_BINARY_DIR}/proto
     PROTOC_OUT_DIR ${CMAKE_BINARY_DIR}/proto
   )

--- a/lrauv_ignition_plugins/src/HydrodynamicsPlugin.cc
+++ b/lrauv_ignition_plugins/src/HydrodynamicsPlugin.cc
@@ -22,7 +22,7 @@
 
 #include "HydrodynamicsPlugin.hh"
 
-#include <Eigen/Eigen>
+#include <eigen3/Eigen/Eigen>
 
 #include <gz/msgs.hh>
 

--- a/lrauv_ignition_plugins/src/comms/CMakeLists.txt
+++ b/lrauv_ignition_plugins/src/comms/CMakeLists.txt
@@ -8,8 +8,8 @@ add_subdirectory(models/)
 add_library(acoustic_comms_support SHARED CommsPacket.cc)
 
 target_link_libraries(acoustic_comms_support PUBLIC
-  gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
-  gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
+  gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
+  gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
   lrauv_acoustic_message
   lrauv_internal_comms
 )

--- a/lrauv_ignition_plugins/src/comms/CMakeLists.txt
+++ b/lrauv_ignition_plugins/src/comms/CMakeLists.txt
@@ -8,8 +8,8 @@ add_subdirectory(models/)
 add_library(acoustic_comms_support SHARED CommsPacket.cc)
 
 target_link_libraries(acoustic_comms_support PUBLIC
-  ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
-  ignition-gazebo${IGN_GAZEBO_VER}::ignition-gazebo${IGN_GAZEBO_VER}
+  gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
+  gz-sim${IGN_GAZEBO_VER}::gz-sim${IGN_GAZEBO_VER}
   lrauv_acoustic_message
   lrauv_internal_comms
 )

--- a/lrauv_ignition_plugins/src/comms/models/CMakeLists.txt
+++ b/lrauv_ignition_plugins/src/comms/models/CMakeLists.txt
@@ -6,7 +6,7 @@
 add_library(simple_acoustic_model SHARED SimpleAcousticModel.cc)
 
 target_link_libraries(simple_acoustic_model PUBLIC
-  gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
+  gz-plugin${GZ_PLUGIN_VER}::gz-plugin${GZ_PLUGIN_VER}
   acoustic_comms_support
 )
 

--- a/lrauv_ignition_plugins/src/comms/models/CMakeLists.txt
+++ b/lrauv_ignition_plugins/src/comms/models/CMakeLists.txt
@@ -6,7 +6,7 @@
 add_library(simple_acoustic_model SHARED SimpleAcousticModel.cc)
 
 target_link_libraries(simple_acoustic_model PUBLIC
-  ignition-plugin${IGN_PLUGIN_VER}::ignition-plugin${IGN_PLUGIN_VER}
+  gz-plugin${IGN_PLUGIN_VER}::gz-plugin${IGN_PLUGIN_VER}
   acoustic_comms_support
 )
 

--- a/lrauv_system_tests/CMakeLists.txt
+++ b/lrauv_system_tests/CMakeLists.txt
@@ -7,9 +7,9 @@ cmake_minimum_required(VERSION 3.5)
 
 project(lrauv_system_tests)
 
-find_package(ignition-gazebo7 REQUIRED)
-find_package(ignition-math7 REQUIRED)
-find_package(ignition-transport12 REQUIRED)
+find_package(gz-sim7 REQUIRED)
+find_package(gz-math7 REQUIRED)
+find_package(gz-transport12 REQUIRED)
 find_package(lrauv_ignition_plugins REQUIRED)
 
 # Build-time constants
@@ -37,9 +37,9 @@ add_library(${PROJECT_NAME}_support
 target_include_directories(${PROJECT_NAME}_support PUBLIC
   include ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_link_libraries(${PROJECT_NAME}_support PUBLIC
-  ignition-gazebo7::ignition-gazebo7
-  ignition-math7::ignition-math7
-  ignition-transport12::ignition-transport12
+  gz-sim7::gz-sim7
+  gz-math7::gz-math7
+  gz-transport12::gz-transport12
   lrauv_ignition_plugins::lrauv_command
   lrauv_ignition_plugins::lrauv_state
   gtest)


### PR DESCRIPTION
Signed-off-by: Aditya <aditya050995@gmail.com>

This makes the ``find_package()`` and linking macros use the ``gz`` prefixed package names.