### PR TITLE
Add DVL mods to WorldCommPlugin

### DIFF
--- a/lrauv_ignition_plugins/src/WorldCommPlugin.cc
+++ b/lrauv_ignition_plugins/src/WorldCommPlugin.cc
@@ -278,6 +278,10 @@ std::string WorldCommPlugin::TethysSdfString(const lrauv_ignition_plugins::msgs:
           <topic>/)" + _id + R"(/ahrs/magnetometer</topic>
         </sensor>
 
+        <sensor element_id="base_link::teledyne_pathfinder_dvl" action="modify">
+          <topic>/)" + _id + R"(/dvl/velocity</topic>
+        </sensor>
+
         <plugin element_id="gz::sim::systems::Thruster" action="modify">
           <namespace>)" + _id + R"(</namespace>
         </plugin>


### PR DESCRIPTION
Adds vehicle specific mods to the DVL topic name during spawn. 