### PR TITLE
Typo on range bearing response topic documentation

### DIFF
--- a/lrauv_ignition_plugins/src/RangeBearingPlugin.hh
+++ b/lrauv_ignition_plugins/src/RangeBearingPlugin.hh
@@ -50,7 +50,7 @@ class RangeBearingPrivateData;
 /// `/{namespace}/range_bearing/requests` for incoming requests using the 
 /// `lrauv_ignition_plugins::msgs::LRAUVRangeBearingRequest` message and will 
 /// respond using the `lrauv_ignition_plugins::msgs::LRAUVRangeBearingResponse` 
-/// message on the `/{namespace}/range_bearing/response` topic.
+/// message on the `/{namespace}/range_bearing/responses` topic.
 ///
 class RangeBearingPlugin:
   public gz::sim::System,


### PR DESCRIPTION
Signed-off-by: Marco A. Gutierrez <marco@openrobotics.org>

Documentation seems to have a typo that can give some trouble to an end user of the Range Bearing Plugin. According to [this](https://github.com/osrf/lrauv/blob/fc7b0647f90549d8ce5b2d1f2eb4b78dec2abc98/lrauv_ignition_plugins/src/RangeBearingPlugin.cc#L284), it seems that it publishes reponses on `/{namespace}/range_bearing/responses` instead of `/{namespace}/range_bearing/response`.