### PR TITLE
Multi LRAUV acoustic comms demo

### DIFF
--- a/lrauv_ignition_plugins/CMakeLists.txt
+++ b/lrauv_ignition_plugins/CMakeLists.txt
@@ -219,7 +219,8 @@ foreach(EXAMPLE
   example_spawn
   example_thruster
   keyboard_teleop
-  multi_lrauv_race)
+  multi_lrauv_race
+  multi_lrauv_acoustic_demo)
 
   set(EXAMPLE_EXEC LRAUV_${EXAMPLE})
 
@@ -229,7 +230,7 @@ foreach(EXAMPLE
     gz-sim${GZ_SIM_VER}::gz-sim${GZ_SIM_VER}
     dvl_velocity_tracking lrauv_acoustic_message lrauv_command lrauv_init
     lrauv_internal_comms lrauv_range_bearing_request lrauv_range_bearing_response
-    lrauv_state)
+    lrauv_state acoustic_comms_support)
 
   install(
     TARGETS ${EXAMPLE_EXEC}

--- a/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
+++ b/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2022 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/*
+ * Development of this module has been funded by the Monterey Bay Aquarium
+ * Research Institute (MBARI) and the David and Lucile Packard Foundation
+ */
+
+/*
+ * In each iteration, for each vehicle, generate a random fin angle and thrust
+ * within reasonable limits, and send the command to the vehicle.
+ *
+ * Usage:
+ *   $ LRAUV_multi_lrauv_race
+ */
+
+#include <chrono>
+#include <thread>
+
+#include <gz/msgs.hh>
+#include <gz/transport.hh>
+#include "lrauv_ignition_plugins/lrauv_command.pb.h"
+#include <lrauv_ignition_plugins/lrauv_acoustic_message.pb.h>
+
+#include <lrauv_ignition_plugins/comms/CommsClient.hh>
+#include <lrauv_ignition_plugins/comms/CommsPacket.hh>
+
+using namespace tethys;
+
+/* This is a simple demonstration of the acoustic comms plugin */
+/* when used with LRAUV vehicles. It consists of 3 vehicles, */
+/* Triton, Daphne, and Tethys floating side by side. Triton send */
+/* a move command using acoustic comms, to the other 2 vehicles, */
+/* which start moving on receiving the command. The speed of sound */
+/* is purposely slowed down here to shw that the middle vehicle (Daphne) */
+/* will receive the signal earlier than Tethys. */
+
+/*    ┌─┐            ┌─┐           ┌─┐ */
+/*    │ │            │ │           │ │ */
+/*    │ │            │ │           │ │ */
+/*    │ │            │ │           │ │ */
+/*    └─┘            └─┘           └─┘ */
+/*   Triton         Daphne        Tethys */
+
+int main(int argc, char** argv)
+{
+  // Initialize random seed
+  srand(time(NULL));
+
+  std::vector<std::string> ns;
+  ns.push_back("triton");
+  ns.push_back("daphne");
+  ns.push_back("tethys");
+
+  gz::transport::Node node;
+
+  std::vector<std::string> cmdTopics;
+  cmdTopics.resize(ns.size(), "");
+  std::vector<gz::transport::Node::Publisher> cmdPubs;
+  cmdPubs.resize(ns.size());
+
+  // Set up topic names and publishers for velocity command.
+  for (int i = 0; i < ns.size(); i++)
+  {
+    cmdTopics[i] = gz::transport::TopicUtils::AsValidTopic(
+      ns[i] + "/command_topic");
+    cmdPubs[i] = node.Advertise<lrauv_ignition_plugins::msgs::LRAUVCommand>(
+      cmdTopics[i]);
+  }
+
+  std::vector<double> propellerCmds = {20, 0 ,0};
+
+  // Set up publishers and callbacks for comms topics.
+  auto senderAddressTriton = 2;
+  CommsClient sender(senderAddressTriton, [](const auto){});
+
+  auto receiverAddressTethys = 1;
+  CommsClient receiverTethys(receiverAddressTethys, [&](const auto message)
+  {
+    std::cout << "Tethys received move command !" << std::endl;
+    if (message.data() == "START")
+    {
+      propellerCmds[2] = 20;
+    }
+  });
+
+  auto receiverAddressDaphne = 3;
+  CommsClient receiverDaphne(receiverAddressDaphne, [&](const auto message)
+  {
+    std::cout << "Daphne received move command !" << std::endl;
+    if (message.data() == "START")
+    {
+      propellerCmds[1] = 20;
+    }
+  });
+
+  // Send move command message from triton
+  LRAUVAcousticMessage message1;
+  message1.set_to(receiverAddressTethys);
+  message1.set_from(senderAddressTriton);
+  message1.set_type(LRAUVAcousticMessageType);
+  message1.set_data("START");
+
+  LRAUVAcousticMessage message2;
+  message2.set_to(receiverAddressDaphne);
+  message2.set_from(senderAddressTriton);
+  message2.set_type(LRAUVAcousticMessageType);
+  message2.set_data("START");
+
+  while (true)
+  {
+    if (propellerCmds[1] == 0 && propellerCmds[2] == 0)
+    {
+      sender.SendPacket(message1);
+      sender.SendPacket(message2);
+    }
+
+    std::cout << "--------------------" << std::endl;
+    std::cout << "Commanded speeds: " << std::endl;
+    for (int i = 0; i < ns.size(); i++)
+    {
+      lrauv_ignition_plugins::msgs::LRAUVCommand cmdMsg;
+      cmdMsg.set_rudderangleaction_(0);
+      cmdMsg.set_propomegaaction_(propellerCmds[i]);
+      std::cout << ns[i] << " : " << propellerCmds[i] << std::endl;
+      cmdMsg.set_buoyancyaction_(0.0005);
+      cmdPubs[i].Publish(cmdMsg);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+  }
+}

--- a/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
+++ b/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
@@ -25,7 +25,10 @@
  * within reasonable limits, and send the command to the vehicle.
  *
  * Usage:
- *   $ LRAUV_multi_lrauv_race
+ *   * Launch gazebo sim using : 
+ *     $ gz sim -v 4 -r multi_lrauv_acoustic_demo.sdf
+ *   * In another terminal, run the demo executable:
+ *     $ LRAUV_multi_lrauv_acoustic_demo
  */
 
 #include <chrono>

--- a/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
+++ b/lrauv_ignition_plugins/example/multi_lrauv_acoustic_demo.cc
@@ -21,9 +21,6 @@
  */
 
 /*
- * In each iteration, for each vehicle, generate a random fin angle and thrust
- * within reasonable limits, and send the command to the vehicle.
- *
  * Usage:
  *   * Launch gazebo sim using : 
  *     $ gz sim -v 4 -r multi_lrauv_acoustic_demo.sdf
@@ -46,11 +43,11 @@ using namespace tethys;
 
 /* This is a simple demonstration of the acoustic comms plugin */
 /* when used with LRAUV vehicles. It consists of 3 vehicles, */
-/* Triton, Daphne, and Tethys floating side by side. Triton send */
+/* Triton, Daphne, and Tethys floating side by side. Triton sends */
 /* a move command using acoustic comms, to the other 2 vehicles, */
 /* which start moving on receiving the command. The speed of sound */
-/* is purposely slowed down here to shw that the middle vehicle (Daphne) */
-/* will receive the signal earlier than Tethys. */
+/* is purposely slowed down here to show that the middle vehicle (Daphne) */
+/* will receive the signal and start moving before Tethys. */
 
 /*    ┌─┐            ┌─┐           ┌─┐ */
 /*    │ │            │ │           │ │ */

--- a/lrauv_ignition_plugins/worlds/multi_lrauv_acoustic_demo.sdf
+++ b/lrauv_ignition_plugins/worlds/multi_lrauv_acoustic_demo.sdf
@@ -1,0 +1,206 @@
+<?xml version="1.0" ?>
+<!--
+  Development of this module has been funded by the Monterey Bay Aquarium
+  Research Institute (MBARI) and the David and Lucile Packard Foundation
+-->
+<sdf version="1.9">
+  <world name="multi_lrauv">
+    <scene>
+      <!-- For turquoise ambient to match particle effect -->
+      <ambient>0.0 1.0 1.0</ambient>
+      <!-- For default gray ambient -->
+      <!--background>0.8 0.8 0.8</background-->
+      <background>0.0 0.7 0.8</background>
+    </scene>
+
+    <physics name="1ms" type="ode">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+
+    <plugin
+      filename="ignition-gazebo-imu-system"
+      name="gz::sim::systems::Imu">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-magnetometer-system"
+      name="gz::sim::systems::Magnetometer">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-buoyancy-system"
+      name="gz::sim::systems::Buoyancy">
+      <uniform_fluid_density>1025</uniform_fluid_density>
+    </plugin>
+    <plugin
+      filename="gz-sim-acoustic-comms-system"
+      name="gz::sim::systems::AcousticComms">
+      <max_range>2500</max_range>
+      <speed_of_sound>3</speed_of_sound>
+    </plugin>
+
+    <!-- Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <plugin
+      filename="ignition-gazebo-particle-emitter2-system"
+      name="gz::sim::systems::ParticleEmitter2">
+    </plugin>
+
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>1 1 1 1</diffuse>
+      <specular>0.5 0.5 0.5 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <!-- Uncomment if you need a ground plane -->
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+    <!-- Particle effect
+      Requires ParticleEmitter2 in ign-gazebo 4.8.0, which will be copied
+      to ParticleEmitter in Ignition G.
+      See https://github.com/ignitionrobotics/ign-gazebo/pull/730 -->
+    <include>
+      <pose>-5 0 0 0 0 0</pose>
+      <uri>turbidity_generator</uri>
+    </include>
+
+    <include>
+      <pose>0 0 1 0 0 1.57</pose>
+      <uri>tethys_equipped</uri>
+    </include>
+
+    <include>
+      <pose>0 15 1 0 0 1.57</pose>
+      <uri>tethys_equipped</uri>
+      <name>triton</name>
+
+      <experimental:params>
+        <sensor element_id="base_link::salinity_sensor" action="modify">
+          <topic>/model/triton/salinity</topic>
+        </sensor>
+        <sensor element_id="base_link::temperature_sensor" action="modify">
+          <topic>/model/triton/temperature</topic>
+        </sensor>
+        <sensor element_id="base_link::chlorophyll_sensor" action="modify">
+          <topic>/model/triton/chlorophyll</topic>
+        </sensor>
+        <sensor element_id="base_link::current_sensor" action="modify">
+          <topic>/model/triton/current</topic>
+        </sensor>
+        <plugin element_id="gz::sim::systems::Thruster" action="modify">
+          <namespace>triton</namespace>
+        </plugin>
+        <plugin element_id="tethys::TethysCommPlugin" action="modify">
+          <namespace>triton</namespace>
+          <command_topic>triton/command_topic</command_topic>
+          <state_topic>triton/state_topic</state_topic>
+        </plugin>
+        <plugin element_id="gz::sim::systems::BuoyancyEngine" action="modify">
+          <namespace>triton</namespace>
+        </plugin>
+        <plugin element_id="gz::sim::systems::DetachableJoint" action="modify">
+          <topic>/model/triton/drop_weight</topic>
+        </plugin>
+        <plugin element_id="gz::sim::systems::CommsEndpoint" action="modify">
+          <address>2</address>
+          <topic>2/rx</topic>
+        </plugin>
+        <plugin element_id="tethys::RangeBearingPlugin" action="modify">
+          <address>2</address>
+          <namespace>triton</namespace>
+        </plugin>
+      </experimental:params>
+
+    </include>
+
+    <include>
+      <pose>0 -15 1 0 0 1.57</pose>
+      <uri>tethys_equipped</uri>
+      <name>daphne</name>
+
+      <experimental:params>
+        <sensor element_id="base_link::salinity_sensor" action="modify">
+          <topic>/model/daphne/salinity</topic>
+        </sensor>
+        <sensor element_id="base_link::temperature_sensor" action="modify">
+          <topic>/model/daphne/temperature</topic>
+        </sensor>
+        <sensor element_id="base_link::chlorophyll_sensor" action="modify">
+          <topic>/model/daphne/chlorophyll</topic>
+        </sensor>
+        <sensor element_id="base_link::current_sensor" action="modify">
+          <topic>/model/daphne/current</topic>
+        </sensor>
+        <plugin element_id="gz::sim::systems::Thruster" action="modify">
+          <namespace>daphne</namespace>
+        </plugin>
+        <plugin element_id="tethys::TethysCommPlugin" action="modify">
+          <namespace>daphne</namespace>
+          <command_topic>daphne/command_topic</command_topic>
+          <state_topic>daphne/state_topic</state_topic>
+        </plugin>
+        <plugin element_id="gz::sim::systems::BuoyancyEngine" action="modify">
+          <namespace>daphne</namespace>
+        </plugin>
+        <plugin element_id="gz::sim::systems::DetachableJoint" action="modify">
+          <topic>/model/daphne/drop_weight</topic>
+        </plugin>
+        <plugin element_id="gz::sim::systems::CommsEndpoint" action="modify">
+          <address>3</address>
+          <topic>3/rx</topic>
+        </plugin>
+        <plugin element_id="tethys::RangeBearingPlugin" action="modify">
+          <address>3</address>
+          <namespace>daphne</namespace>
+        </plugin>
+      </experimental:params>
+
+    </include>
+
+  </world>
+</sdf>


### PR DESCRIPTION
This PR aims to add a demo world with acoustic comms and multiple LRAUVs. It consists of 3 vehicles placed side by side each other, with one of them sending the signal to start moving. Since the speed of sound is slowed down, it is visible clearly when sound reaches the farther vehicle slightly later and they start moving accordingly. The lag is visible clearly in the motion of the vehicles.

To run, execute : 
`` gz sim -v 4 -r multi_lrauv_acoustic_demo.sdf --render-engine ogre`` in one terminal
and
``./install/lrauv_ignition_plugins/bin/LRAUV_multi_lrauv_acoustic_demo`` in another one, after the sim launches.

![image](https://user-images.githubusercontent.com/18661155/185722741-2463b681-e12a-4264-847b-397788b5531c.png)


Signed-off-by: Aditya <aditya050995@gmail.com>