### PR TITLE
Build Gazebo Garden from source only when needed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,23 @@ jobs:
       if: github.event_name != 'workflow_dispatch'
     - name: Inject slug/short variables
       uses: rlespinasse/github-slug-action@v4
+    - name: Get branch name
+      id: branch-name
+      uses: tj-actions/branch-names@v6
+    - name: Compute last successfully built commit
+      uses: nrwl/last-successful-commit-action@v1
+      id: last-commit
+      with:
+        branch: ${{ steps.branch-name.outputs.current_branch }}
+        workflow_id: 'ci.yaml'
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+      if: github.event_name != 'workflow_dispatch'
     - name: Check base image files for changes since last commit
       id: base-image-files-in-last-commit
       uses: tj-actions/changed-files@v28.0.0
       with:
         files: docker/base/*
+        base_sha: ${{ steps.last-commit.outputs.commit_hash }}
       if: github.event_name != 'workflow_dispatch'
     - name: Check if base image needs to be (re)built
       id: should-build-base-image
@@ -47,7 +59,7 @@ jobs:
       id: compute-base-image
       run: |
         suffix="latest"
-        if [[ "${{ github.ref_name }}" != "${{ github.event.repository.default_branch }}" ]]; then
+        if ! ${{ steps.branch-name.outputs.is_default }}; then
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             suffix="$GITHUB_REF_SLUG"
           fi

--- a/lrauv_ignition_plugins/src/TimeAnalysisPlugin.cc
+++ b/lrauv_ignition_plugins/src/TimeAnalysisPlugin.cc
@@ -23,8 +23,10 @@
 #include <chrono>
 
 #include <gz/sim/World.hh>
+#include <gz/msgs/boolean.pb.h>
 #include <gz/msgs/double.pb.h>
 #include <gz/msgs/header.pb.h>
+#include <gz/msgs/physics.pb.h>
 #include <gz/msgs/time.pb.h>
 #include <gz/msgs/world_stats.pb.h>
 #include <gz/plugin/Register.hh>

--- a/lrauv_ignition_plugins/src/WorldConfigPlugin.cc
+++ b/lrauv_ignition_plugins/src/WorldConfigPlugin.cc
@@ -22,6 +22,7 @@
 
 #include "WorldConfigPlugin.hh"
 #include <gz/common/Console.hh>
+#include <gz/msgs/stringmsg.pb.h>
 #include <gz/plugin/Register.hh>
 
 #include <gz/gui/Application.hh>

--- a/lrauv_system_tests/test/vehicle/test_sensor.cc
+++ b/lrauv_system_tests/test/vehicle/test_sensor.cc
@@ -24,6 +24,7 @@
 #include <thread>
 #include <gtest/gtest.h>
 
+#include <gz/msgs/float.pb.h>
 #include <gz/sim/TestFixture.hh>
 #include <gz/sim/Util.hh>
 #include <gz/sim/World.hh>

--- a/lrauv_system_tests/test/vehicle/test_sensor_timeinterpolation.cc
+++ b/lrauv_system_tests/test/vehicle/test_sensor_timeinterpolation.cc
@@ -24,6 +24,7 @@
 #include <thread>
 #include <gtest/gtest.h>
 
+#include <gz/msgs/double.pb.h>
 #include <gz/sim/TestFixture.hh>
 #include <gz/sim/Util.hh>
 #include <gz/sim/World.hh>


### PR DESCRIPTION
Follow-up after #239. It looks like I misinterpreted https://github.com/marketplace/actions/changed-files docs. This patch should ensure we build Gazebo Garden from source only when strictly necessary or explicitly required. 