### PR TITLE
Install lrauv_system_tests package.

### DIFF
--- a/lrauv_system_tests/CMakeLists.txt
+++ b/lrauv_system_tests/CMakeLists.txt
@@ -10,6 +10,7 @@ project(lrauv_system_tests)
 find_package(gz-sim7 REQUIRED)
 find_package(gz-math7 REQUIRED)
 find_package(gz-transport12 REQUIRED)
+find_package(gz-common5 REQUIRED)
 find_package(lrauv_gazebo_plugins REQUIRED)
 
 # Build-time constants
@@ -34,14 +35,51 @@ add_library(${PROJECT_NAME}_support
   src/Publisher.cc
 )
 target_include_directories(${PROJECT_NAME}_support PUBLIC
-  include ${CMAKE_CURRENT_BINARY_DIR}/include)
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
 target_link_libraries(${PROJECT_NAME}_support PUBLIC
   gz-sim7::gz-sim7
   gz-math7::gz-math7
   gz-transport12::gz-transport12
+  gz-common5::gz-common5
   lrauv_gazebo_plugins::lrauv_gazebo_messages
   gtest)
 target_compile_features(${PROJECT_NAME}_support PUBLIC cxx_std_17)
+#============================================================================
+# Install
+install(
+  DIRECTORY include/
+  DESTINATION include
+  FILES_MATCHING
+  PATTERN "*.hh"
+)
+
+install(
+  TARGETS ${PROJECT_NAME}_support
+  EXPORT ${PROJECT_NAME}
+  DESTINATION lib
+)
+
+#============================================================================
+# Exports
+install(
+  EXPORT ${PROJECT_NAME}
+  FILE ${PROJECT_NAME}-targets.cmake
+  NAMESPACE ${PROJECT_NAME}::
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+  INSTALL_DESTINATION "share/${PROJECT_NAME}/cmake"
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO)
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  DESTINATION share/${PROJECT_NAME}/cmake)
+
 #============================================================================
 # Tests
 include(CTest)

--- a/lrauv_system_tests/cmake/Config.cmake.in
+++ b/lrauv_system_tests/cmake/Config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include ( "${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake" )

--- a/lrauv_system_tests/include/TestConstants.hh.in
+++ b/lrauv_system_tests/include/TestConstants.hh.in
@@ -1,5 +1,15 @@
 #ifndef __TEST_CONSTANTS_HH__
 #define __TEST_CONSTANTS_HH__
+
+#include <string>
+#include <gz/common/Filesystem.hh>
+
 #define PROJECT_BINARY_PATH "@PROJECT_BINARY_PATH@"
 #define PROJECT_SOURCE_PATH "@PROJECT_SOURCE_PATH@"
+
+inline std::string worldPath(const std::string &_basename)
+{
+  return gz::common::joinPaths(PROJECT_SOURCE_PATH "/worlds", _basename);
+}
+
 #endif

--- a/lrauv_system_tests/include/lrauv_system_tests/TestFixture.hh
+++ b/lrauv_system_tests/include/lrauv_system_tests/TestFixture.hh
@@ -41,8 +41,6 @@
 #include "lrauv_system_tests/ModelObserver.hh"
 #include "lrauv_system_tests/Subscription.hh"
 
-#include "TestConstants.hh"
-
 namespace lrauv_system_tests
 {
 
@@ -52,11 +50,9 @@ namespace lrauv_system_tests
 class TestFixture
 {
   /// Constructor.
-  /// \param[in] _worldName Base name of the world SDF,
-  /// to be found among this package's ``worlds``.
-  public: TestFixture(const std::string &_worldName)
-    : fixture(gz::common::joinPaths(
-          PROJECT_SOURCE_PATH, "worlds", _worldName))
+  /// \param[in] _worldPath Paht to world SDF.
+  public: TestFixture(const std::string &_worldPath)
+    : fixture(_worldPath)
   {
     gz::common::Console::SetVerbosity(4);
   }
@@ -189,13 +185,12 @@ class TestFixture
 class TestFixtureWithVehicle : public TestFixture
 {
   /// Constructor.
-  /// \param[in] _worldName Base name of the world SDF,
-  /// to be found among this package's ``worlds``.
+  /// \param[in] _worldPath Path to world SDF.
   /// \param[in] _vehicleName Name of the vehicle model.
   public: TestFixtureWithVehicle(
-      const std::string &_worldName,
+      const std::string &_worldPath,
       const std::string &_vehicleName)
-    : TestFixture(_worldName),
+    : TestFixture(_worldPath),
       vehicleManipulator(_vehicleName),
       vehicleObserver(_vehicleName),
       vehicleName(_vehicleName)
@@ -245,13 +240,12 @@ class TestFixtureWithVehicle : public TestFixture
 class VehicleCommandTestFixture : public TestFixtureWithVehicle
 {
   /// Constructor.
-  /// \param[in] _worldName Base name of the world SDF,
-  /// to be found among this package's ``worlds``.
+  /// \param[in] _worldPath Path to world SDF.
   /// \param[in] _vehicleName Name of the vehicle model.
   public: VehicleCommandTestFixture(
-      const std::string &_worldName,
+      const std::string &_worldPath,
       const std::string &_vehicleName)
-    : TestFixtureWithVehicle(_worldName, _vehicleName)
+    : TestFixtureWithVehicle(_worldPath, _vehicleName)
   {
     using lrauv_gazebo_plugins::msgs::LRAUVCommand;
     const std::string topicName = "/" + _vehicleName + "/command_topic";
@@ -277,13 +271,12 @@ class VehicleStateTestFixture : public VehicleCommandTestFixture
   using LRAUVState = lrauv_gazebo_plugins::msgs::LRAUVState;
 
   /// Constructor.
-  /// \param[in] _worldName Base name of the world SDF,
-  /// to be found among this package's ``worlds``.
+  /// \param[in] _worldPath Path to world SDF.
   /// \param[in] _vehicleName Name of the vehicle model.
   public: VehicleStateTestFixture(
-      const std::string &_worldName,
+      const std::string &_worldPath,
       const std::string &_vehicleName)
-    : VehicleCommandTestFixture(_worldName, _vehicleName)
+    : VehicleCommandTestFixture(_worldPath, _vehicleName)
   {
     const std::string topicName = "/" + _vehicleName + "/state_topic";
     this->stateSubscription.Subscribe(this->Node(), topicName, 1);

--- a/lrauv_system_tests/src/ModelObserver.cc
+++ b/lrauv_system_tests/src/ModelObserver.cc
@@ -1,7 +1,5 @@
 #include "lrauv_system_tests/ModelObserver.hh"
 
-#include <gtest/gtest.h>
-
 #include <gz/sim/Link.hh>
 #include <gz/sim/Model.hh>
 #include <gz/sim/Util.hh>
@@ -48,7 +46,6 @@ void ModelObserver::Update(
     gz::sim::Model model(modelEntity);
     const gz::sim::Entity linkEntity =
         model.LinkByName(_ecm, this->baseLinkName);
-    ASSERT_NE(gz::sim::kNullEntity, linkEntity);
     gz::sim::Link link(linkEntity);
 
     auto linearVelocity = link.WorldLinearVelocity(_ecm);

--- a/lrauv_system_tests/test/dynamics/test_hydrodynamics.cc
+++ b/lrauv_system_tests/test/dynamics/test_hydrodynamics.cc
@@ -32,12 +32,15 @@
 #include "lrauv_system_tests/ModelObserver.hh"
 #include "lrauv_system_tests/Publisher.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 using namespace std::literals::chrono_literals;
 
 class HydrodynamicsTestFixture : public TestFixture
 {
-  public: HydrodynamicsTestFixture() : TestFixture("star_world.sdf")
+  public: HydrodynamicsTestFixture() :
+    TestFixture(worldPath("star_world.sdf"))
   {
     for (size_t i = 0; i < 4; ++i)
     {

--- a/lrauv_system_tests/test/dynamics/test_hydrostatics.cc
+++ b/lrauv_system_tests/test/dynamics/test_hydrostatics.cc
@@ -40,7 +40,7 @@ using namespace lrauv_system_tests;
 TEST(HydrostaticStability, NeutralBuoyancy)
 {
   TestFixtureWithVehicle fixture(
-    "flat_tethys_no_damping.sdf", "tethys");
+    worldPath("flat_tethys_no_damping.sdf"), "tethys");
   fixture.Step(10000u);
 
   auto &observer = fixture.VehicleObserver();
@@ -63,7 +63,7 @@ TEST(HydrostaticStability, NeutralBuoyancy)
 TEST(HydrostaticStability, RestoringMoment)
 {
   TestFixtureWithVehicle fixture(
-    "tilted_tethys_no_damping.sdf", "tethys");
+    worldPath("tilted_tethys_no_damping.sdf"), "tethys");
 
   fixture.Step(10000u);
 

--- a/lrauv_system_tests/test/environment/test_currents.cc
+++ b/lrauv_system_tests/test/environment/test_currents.cc
@@ -35,7 +35,7 @@ using namespace std::literals::chrono_literals;
 TEST(CurrentsTest, TestGlobalCurrent)
 {
   TestFixtureWithVehicle fixture(
-      "buoyant_tethys_at_depth.sdf", "tethys");
+      worldPath("buoyant_tethys_at_depth.sdf"), "tethys");
   gz::transport::Node node;
   auto pub = node.Advertise<gz::msgs::Vector3d>("/ocean_current");
   gz::msgs::Vector3d vec;

--- a/lrauv_system_tests/test/environment/test_surface_winds.cc
+++ b/lrauv_system_tests/test/environment/test_surface_winds.cc
@@ -34,7 +34,8 @@ using namespace std::literals::chrono_literals;
 //////////////////////////////////////////////////
 TEST(SurfaceWindsTest, WindAtSurface)
 {
-  TestFixtureWithVehicle fixture("windy_tethys.sdf", "tethys");
+  TestFixtureWithVehicle fixture(
+      worldPath("windy_tethys.sdf"), "tethys");
   fixture.Step(2min);
   // Eastward velocity at the surface due to wind
   // NOTE(hidmic): reverse Y-axis velocity sign to match FSK
@@ -47,7 +48,7 @@ TEST(SurfaceWindsTest, WindAtSurface)
 TEST(SurfaceWindsTest, NoWindAtDepth)
 {
   TestFixtureWithVehicle fixture(
-      "windy_tethys_at_depth.sdf", "tethys");
+      worldPath("windy_tethys_at_depth.sdf"), "tethys");
   fixture.Step(2min);
   // No eastward velocity at a depth due to wind
   const auto &observer = fixture.VehicleObserver();

--- a/lrauv_system_tests/test/simulation/test_spawn.cc
+++ b/lrauv_system_tests/test/simulation/test_spawn.cc
@@ -39,15 +39,14 @@
 #include "lrauv_system_tests/TestFixture.hh"
 #include "lrauv_system_tests/Util.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 using namespace std::literals::chrono_literals;
 
 class DynamicTestFixture : public TestFixture
 {
-  public: DynamicTestFixture(const std::string &_worldName)
-    : TestFixture(_worldName)
-  {
-  }
+  using TestFixture::TestFixture;
 
   public: ModelObserver &Observe(const std::string &_modelName)
   {
@@ -72,7 +71,7 @@ class DynamicTestFixture : public TestFixture
 //////////////////////////////////////////////////
 TEST(VehicleSpawnTest, Spawn)
 {
-  DynamicTestFixture fixture("empty_environment.sdf");
+  DynamicTestFixture fixture(worldPath("empty_environment.sdf"));
   auto &observer1 = fixture.Observe("vehicle1");
   auto &observer2 = fixture.Observe("vehicle2");
 

--- a/lrauv_system_tests/test/simulation/test_state.cc
+++ b/lrauv_system_tests/test/simulation/test_state.cc
@@ -31,11 +31,14 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace std::literals::chrono_literals;
 
 class VehicleStateTest : public ::testing::Test
 {
-  public: VehicleStateTest() : fixture("buoyant_tethys.sdf", "tethys")
+  public: VehicleStateTest()
+    : fixture(worldPath("buoyant_tethys.sdf"), "tethys")
   {
   }
 

--- a/lrauv_system_tests/test/vehicle/test_acoustic_comms.cc
+++ b/lrauv_system_tests/test/vehicle/test_acoustic_comms.cc
@@ -35,6 +35,8 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace tethys;
 using namespace lrauv_system_tests;
 
@@ -62,7 +64,7 @@ TEST(AcousticComms, PacketConversions)
 
 TEST(AcousticComms, BasicSendReceive)
 {
-  TestFixture fixture("acoustic_comms_fixture.sdf");
+  TestFixture fixture(worldPath("acoustic_comms_fixture.sdf"));
 
   constexpr int senderAddress = 1;
   CommsClient sender(senderAddress, [](const auto){});
@@ -100,7 +102,7 @@ TEST(AcousticComms, BasicSendReceive)
 
 TEST(AcousticComms, MultiVehicleTest)
 {
-  TestFixture fixture("acoustic_comms_multi_vehicle.sdf");
+  TestFixture fixture(worldPath("acoustic_comms_multi_vehicle.sdf"));
 
   constexpr int senderAddressTriton = 1;
   CommsClient senderTriton(senderAddressTriton, [](const auto){});

--- a/lrauv_system_tests/test/vehicle/test_acoustic_comms_multi_vehicle.cc
+++ b/lrauv_system_tests/test/vehicle/test_acoustic_comms_multi_vehicle.cc
@@ -35,6 +35,8 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace tethys;
 using namespace lrauv_system_tests;
 
@@ -43,7 +45,7 @@ using MessageDifferencer =
 
 TEST(AcousticComms, MultiVehicleTest)
 {
-  TestFixture fixture("acoustic_comms_multi_vehicle.sdf");
+  TestFixture fixture(worldPath("acoustic_comms_multi_vehicle.sdf"));
 
   constexpr int senderAddressTriton = 1;
   CommsClient senderTriton(senderAddressTriton, [](const auto){});

--- a/lrauv_system_tests/test/vehicle/test_ahrs.cc
+++ b/lrauv_system_tests/test/vehicle/test_ahrs.cc
@@ -49,9 +49,9 @@ using namespace std::literals::chrono_literals;
 class AHRSTestFixture : public TestFixtureWithVehicle
 {
   public: AHRSTestFixture(
-      const std::string &_worldName,
+      const std::string &_worldPath,
       const std::string &_vehicleName)
-    : TestFixtureWithVehicle(_worldName, _vehicleName)
+    : TestFixtureWithVehicle(_worldPath, _vehicleName)
   {
     constexpr size_t historyDepth = 1u;
     const std::string imuTopicName =
@@ -131,7 +131,8 @@ inline bool AreQuaternionsEqual(
 //////////////////////////////////////////////////
 TEST(AHRSTest, FrameConventionsAreCorrect)
 {
-  AHRSTestFixture fixture("buoyant_tethys.sdf", "tethys");
+  AHRSTestFixture fixture(
+      worldPath("buoyant_tethys.sdf"), "tethys");
 
   EXPECT_LT(0, fixture.Step(200ms));
 

--- a/lrauv_system_tests/test/vehicle/test_battery_full_charge.cc
+++ b/lrauv_system_tests/test/vehicle/test_battery_full_charge.cc
@@ -28,6 +28,8 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace gz;
 using namespace std::literals::chrono_literals;
 
@@ -37,7 +39,7 @@ using namespace std::literals::chrono_literals;
 TEST(BatteryTest, TestDischargeFullCharged)
 {
   using TestFixture = lrauv_system_tests::TestFixtureWithVehicle;
-  TestFixture fixture("buoyant_tethys.sdf", "tethys");
+  TestFixture fixture(worldPath("buoyant_tethys.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
 
   transport::Node node;

--- a/lrauv_system_tests/test/vehicle/test_battery_half_charge.cc
+++ b/lrauv_system_tests/test/vehicle/test_battery_half_charge.cc
@@ -28,6 +28,8 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace gz;
 using namespace std::literals::chrono_literals;
 
@@ -39,7 +41,7 @@ using namespace std::literals::chrono_literals;
 TEST(BatteryTest, TestDischargeHalfCharged)
 {
   using TestFixture = lrauv_system_tests::TestFixtureWithVehicle;
-  TestFixture fixture("buoyant_tethys_half_battery.sdf", "tethys");
+  TestFixture fixture(worldPath("buoyant_tethys_half_battery.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
 
   transport::Node node;

--- a/lrauv_system_tests/test/vehicle/test_battery_low_charge.cc
+++ b/lrauv_system_tests/test/vehicle/test_battery_low_charge.cc
@@ -30,6 +30,8 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace gz;
 using namespace std::literals::chrono_literals;
 
@@ -41,7 +43,7 @@ using namespace std::literals::chrono_literals;
 TEST(BatteryTest, TestDischargeLowCharge)
 {
   using TestFixture = lrauv_system_tests::VehicleCommandTestFixture;
-  TestFixture fixture("buoyant_tethys_low_battery.sdf", "tethys");
+  TestFixture fixture(worldPath("buoyant_tethys_low_battery.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
 
   transport::Node node;

--- a/lrauv_system_tests/test/vehicle/test_buoyancy_action.cc
+++ b/lrauv_system_tests/test/vehicle/test_buoyancy_action.cc
@@ -27,12 +27,15 @@
 #include <lrauv_gazebo_plugins/lrauv_command.pb.h>
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 
 //////////////////////////////////////////////////
 TEST(BuoyancyActionTest, Sink)
 {
-  VehicleCommandTestFixture fixture("buoyant_tethys.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("buoyant_tethys.sdf"), "tethys");
   EXPECT_EQ(100u, fixture.Step(100u));
 
   // Vehicle is at the surface

--- a/lrauv_system_tests/test/vehicle/test_drop_weight.cc
+++ b/lrauv_system_tests/test/vehicle/test_drop_weight.cc
@@ -27,12 +27,15 @@
 #include <lrauv_gazebo_plugins/lrauv_command.pb.h>
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 
 //////////////////////////////////////////////////
 TEST(DropWeightTest, ReleaseWeight)
 {
-  VehicleCommandTestFixture fixture("buoyant_tethys_at_depth.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("buoyant_tethys_at_depth.sdf"), "tethys");
   EXPECT_EQ(100u, fixture.Step(100u));
 
   // Starting point of the vehicle

--- a/lrauv_system_tests/test/vehicle/test_dvl.cc
+++ b/lrauv_system_tests/test/vehicle/test_dvl.cc
@@ -55,7 +55,8 @@ static constexpr double kRangeTolerance{0.2};
 //////////////////////////////////////////////////
 TEST(DVLTest, NoTracking)
 {
-  VehicleCommandTestFixture fixture("bottomless_pit.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("bottomless_pit.sdf"), "tethys");
 
   Subscription<DVLVelocityTracking> velocitySubscription;
   velocitySubscription.Subscribe(fixture.Node(), "/tethys/dvl/velocity", 1);
@@ -78,7 +79,8 @@ TEST(DVLTest, NoTracking)
 //////////////////////////////////////////////////
 TEST(DVLTest, BottomTracking)
 {
-  VehicleCommandTestFixture fixture("flat_seabed.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("flat_seabed.sdf"), "tethys");
   constexpr double seaBedDepth{20.};
   // Assume zero roll and arbitrary resolution
   const double expectedBeamRange =
@@ -184,7 +186,8 @@ TEST(DVLTest, BottomTracking)
 //////////////////////////////////////////////////
 TEST(DVLTest, WaterMassTracking)
 {
-  VehicleCommandTestFixture fixture("underwater_currents.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("underwater_currents.sdf"), "tethys");
   constexpr gz::math::Vector3d waterCurrentVelocity{-1., 0.5, 0.};
 
   Subscription<DVLVelocityTracking> velocitySubscription;

--- a/lrauv_system_tests/test/vehicle/test_elevator_action.cc
+++ b/lrauv_system_tests/test/vehicle/test_elevator_action.cc
@@ -22,13 +22,15 @@
 #include <lrauv_gazebo_plugins/lrauv_command.pb.h>
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 
 //////////////////////////////////////////////////
 TEST(ElevatorActionTest, Sink)
 {
   VehicleCommandTestFixture fixture(
-      "buoyant_tethys.sdf", "tethys");
+      worldPath("buoyant_tethys.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
   EXPECT_EQ(100u, iterations);
 

--- a/lrauv_system_tests/test/vehicle/test_mass_shifter.cc
+++ b/lrauv_system_tests/test/vehicle/test_mass_shifter.cc
@@ -27,13 +27,15 @@
 #include <lrauv_gazebo_plugins/lrauv_command.pb.h>
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 
 //////////////////////////////////////////////////
 TEST(MassShifterTest, DownwardTilt)
 {
   VehicleCommandTestFixture fixture(
-    "buoyant_tethys_at_depth.sdf", "tethys");
+      worldPath("buoyant_tethys_at_depth.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
   EXPECT_EQ(100u, iterations);
 

--- a/lrauv_system_tests/test/vehicle/test_propeller_action.cc
+++ b/lrauv_system_tests/test/vehicle/test_propeller_action.cc
@@ -27,12 +27,15 @@
 #include <lrauv_gazebo_plugins/lrauv_command.pb.h>
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 
 //////////////////////////////////////////////////
 TEST(PropellerActionTest, ForwardThrust)
 {
-  VehicleCommandTestFixture fixture("buoyant_tethys.sdf", "tethys");
+  VehicleCommandTestFixture fixture(
+      worldPath("buoyant_tethys.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
   EXPECT_EQ(100u, iterations);
 

--- a/lrauv_system_tests/test/vehicle/test_range_bearing.cc
+++ b/lrauv_system_tests/test/vehicle/test_range_bearing.cc
@@ -31,6 +31,8 @@
 #include "lrauv_system_tests/TestFixture.hh"
 #include "lrauv_system_tests/Util.hh"
 
+#include "TestConstants.hh"
+
 using namespace lrauv_system_tests;
 using namespace std::literals::chrono_literals;
 
@@ -39,7 +41,7 @@ TEST(RangeBearingTest, BearingIsCorrect)
 {
   // This world has the robot start at a certain depth
   // and 3 acoustic comms nodes
-  TestFixture fixture("acoustic_comms_fixture.sdf");
+  TestFixture fixture(worldPath("acoustic_comms_fixture.sdf"));
   // Needs to have the server call configure on
   // the RangeBearing plugin before any attempt
   // to request an estimate.

--- a/lrauv_system_tests/test/vehicle/test_rudder_action.cc
+++ b/lrauv_system_tests/test/vehicle/test_rudder_action.cc
@@ -28,11 +28,14 @@
 
 #include "lrauv_system_tests/TestFixture.hh"
 
+#include "TestConstants.hh"
+
 //////////////////////////////////////////////////
 TEST(RudderActionTest, LeftTurn)
 {
   using TestFixture = lrauv_system_tests::VehicleCommandTestFixture;
-  TestFixture fixture("buoyant_tethys_at_depth.sdf", "tethys");
+  TestFixture fixture(
+      worldPath("buoyant_tethys_at_depth.sdf"), "tethys");
   uint64_t iterations = fixture.Step(100u);
   EXPECT_EQ(100u, iterations);
 


### PR DESCRIPTION
Precisely what the title says. This patch enables downstream usage of support code.