### PR TITLE
Adds a friendly warning if the python bindings for gazebo are not found

### DIFF
--- a/lrauv_gazebo_plugins/CMakeLists.txt
+++ b/lrauv_gazebo_plugins/CMakeLists.txt
@@ -51,6 +51,11 @@ find_package (Eigen3 3.3 REQUIRED)
 
 find_package(PCL 1.2 REQUIRED)
 
+find_package(
+  Python3
+  REQUIRED
+  COMPONENTS Interpreter)
+
 # Build protobuf messages
 add_subdirectory(proto)
 
@@ -252,22 +257,35 @@ configure_file(
 
 #============================================================================
 # World generation
-foreach (WORLD_NAME "portuguese_ledge" "dvl_at_portuguese_ledge" "empty_environment_with_tiles")
-  add_custom_command(
-    OUTPUT ${WORLD_NAME}_gen_cmd
-    COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/worlds/empy_expander.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/worlds/${WORLD_NAME}.sdf.em
-    ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
-  )
+execute_process(
+    COMMAND Python3::Interpreter -c "import gz"
+    RESULT_VARIABLE EXIT_CODE
+    OUTPUT_QUIET
+)
 
-  add_custom_target(${WORLD_NAME}_gen_target ALL
-    DEPENDS ${WORLD_NAME}_gen_cmd
-  )
+if (${EXIT_CODE} EQUAL 0)
+  foreach (WORLD_NAME "portuguese_ledge" "dvl_at_portuguese_ledge" "empty_environment_with_tiles")
+    add_custom_command(
+      OUTPUT ${WORLD_NAME}_gen_cmd
+      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/worlds/empy_expander.py
+      ${CMAKE_CURRENT_SOURCE_DIR}/worlds/${WORLD_NAME}.sdf.em
+      ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
+    )
 
-  install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
-    DESTINATION share/${PROJECT_NAME}/worlds)
-endforeach()
+    add_custom_target(${WORLD_NAME}_gen_target ALL
+      DEPENDS ${WORLD_NAME}_gen_cmd
+    )
+
+    install(FILES
+      ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
+      DESTINATION share/${PROJECT_NAME}/worlds)
+  endforeach()
+else()
+  message(
+    WARNING "Could not find the Gazebo Python bindings, some worlds will not be generated.\
+    If you installed gazebo from source, make sure you set the PYTHON_PATH like so\
+    \n\t export PYTHONPATH=$PYTHONPATH:<path to ws>/install/lib/python")
+endif()
 #============================================================================
 # Resources
 install(

--- a/lrauv_gazebo_plugins/CMakeLists.txt
+++ b/lrauv_gazebo_plugins/CMakeLists.txt
@@ -53,7 +53,6 @@ find_package(PCL 1.2 REQUIRED)
 
 find_package(
   Python3
-  REQUIRED
   COMPONENTS Interpreter)
 
 # Build protobuf messages
@@ -257,34 +256,39 @@ configure_file(
 
 #============================================================================
 # World generation
-execute_process(
-    COMMAND Python3::Interpreter -c "import gz"
-    RESULT_VARIABLE EXIT_CODE
-    OUTPUT_QUIET
-)
 
-if (${EXIT_CODE} EQUAL 0)
-  foreach (WORLD_NAME "portuguese_ledge" "dvl_at_portuguese_ledge" "empty_environment_with_tiles")
-    add_custom_command(
-      OUTPUT ${WORLD_NAME}_gen_cmd
-      COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/worlds/empy_expander.py
-      ${CMAKE_CURRENT_SOURCE_DIR}/worlds/${WORLD_NAME}.sdf.em
-      ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
-    )
+if (${Python3_FOUND})
+  execute_process(
+      COMMAND Python3::Interpreter -c "import gz"
+      RESULT_VARIABLE EXIT_CODE
+      OUTPUT_QUIET
+  )
 
-    add_custom_target(${WORLD_NAME}_gen_target ALL
-      DEPENDS ${WORLD_NAME}_gen_cmd
-    )
+  if (${EXIT_CODE} EQUAL 0)
+    foreach (WORLD_NAME "portuguese_ledge" "dvl_at_portuguese_ledge" "empty_environment_with_tiles")
+      add_custom_command(
+        OUTPUT ${WORLD_NAME}_gen_cmd
+        COMMAND python3 ${CMAKE_CURRENT_SOURCE_DIR}/worlds/empy_expander.py
+        ${CMAKE_CURRENT_SOURCE_DIR}/worlds/${WORLD_NAME}.sdf.em
+        ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
+      )
 
-    install(FILES
-      ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
-      DESTINATION share/${PROJECT_NAME}/worlds)
-  endforeach()
+      add_custom_target(${WORLD_NAME}_gen_target ALL
+        DEPENDS ${WORLD_NAME}_gen_cmd
+      )
+
+      install(FILES
+        ${CMAKE_CURRENT_BINARY_DIR}/worlds/${WORLD_NAME}.sdf
+        DESTINATION share/${PROJECT_NAME}/worlds)
+    endforeach()
+  else()
+    message(
+      WARNING "Could not find the Gazebo Python bindings, some worlds will not be generated.\
+      If you installed gazebo from source, make sure you set the PYTHON_PATH like so\
+      \n\t export PYTHONPATH=$PYTHONPATH:<path to ws>/install/lib/python")
+  endif()
 else()
-  message(
-    WARNING "Could not find the Gazebo Python bindings, some worlds will not be generated.\
-    If you installed gazebo from source, make sure you set the PYTHON_PATH like so\
-    \n\t export PYTHONPATH=$PYTHONPATH:<path to ws>/install/lib/python")
+  message(WARNING "Python not found. Some worlds may not be generated.")
 endif()
 #============================================================================
 # Resources


### PR DESCRIPTION
While installing gazebo on a new computer, I ran into trouble with python gazebo bindings.
I believe part of the issue is I have gazebo newly compiled from source. It's not great that
the repo does not compile at all if gz-python is not found, especially since gz-python is not
used by any core dependency. This PR adds a simple check and only runs the world generation
if the python-gazebo package is found. If the package is not found, users can still install the
simulator, however a warning is given warning users that the examples may not work.

I'm only checking for gz, but it might be worth checking for other python packages which may
or maynot come installed with an end user's work space.

Signed-off-by: Arjo Chakravarty <arjo@openrobotics.org>