### PR TITLE
Removes `<namespace>` in joints.

### DIFF
--- a/lrauv_description/models/tethys/model.sdf.in
+++ b/lrauv_description/models/tethys/model.sdf.in
@@ -308,13 +308,11 @@
       <pose>0 0 0 0 0 0</pose>
       <parent>base_link</parent>
       <child>acoustic_transponder</child>
-      <namespace>tethys</namespace>
     </joint>
     <joint name="buoyancy_engine_joint" type="fixed">
       <pose>0 0 0 0 0 0</pose>
       <parent>base_link</parent>
       <child>buoyancy_engine</child>
-      <namespace>tethys</namespace>
     </joint>
     <joint name="horizontal_fins_joint" type="revolute">
       <pose>0 0 0 0 0 0</pose>


### PR DESCRIPTION
I have no idea why there are namespaces in joints. To the best of my knowledge this is not part of the SDFormat spec and it seems that gazebo is complaining about it.