### PR TITLE
Fix fixuid-induced $HOME permission issues

### DIFF
--- a/tools/setup/Dockerfile
+++ b/tools/setup/Dockerfile
@@ -113,6 +113,7 @@ RUN cd $GZ_WS && colcon build --merge-install --cmake-args -DBUILD_TESTING=OFF
 USER root
 RUN echo ". $GZ_WS/install/setup.sh" >> /setup.sh && \
   echo "export PYTHONPATH=$GZ_WS/install/lib/python" >> /setup.sh
+RUN chown -R root:root ${GZ_WS}
 
 USER $USERNAME
 
@@ -137,10 +138,6 @@ RUN mkdir -p $LRAUV_WS/src
 COPY --chown=$USERNAME . $LRAUV_WS/src/lrauv
 WORKDIR $LRAUV_WS
 
-USER root
-RUN printf "user: $USERNAME\ngroup: $USERNAME\npaths: [$LRAUV_WS]" > /etc/fixuid/config.yml
-USER $USERNAME
-
 # Run tests by default
 COPY --chown=$USERNAME tools/setup/build-then-test.sh $LRAUV_WS/build-then-test.sh
 CMD $LRAUV_WS/build-then-test.sh
@@ -155,6 +152,7 @@ RUN cd $LRAUV_WS; . /setup.sh; \
 
 USER root
 RUN echo ". $LRAUV_WS/install/setup.sh" >> /setup.sh
+RUN chown -R root:root ${LRAUV_WS}
 
 # Run simulation by default
 USER $USERNAME

--- a/tools/setup/enter-container.sh
+++ b/tools/setup/enter-container.sh
@@ -36,10 +36,10 @@ CONTAINER_IMAGE=${1:-$(cat $WORKSPACE_DIR/.image)}
 CONTAINER_ID=$(docker ps -aqf "ancestor=${CONTAINER_IMAGE}")
 if [ -z "$CONTAINER_ID" ]; then
     CONTAINER_NAME="$(basename $WORKSPACE_DIR)_$(date +%s)"
-    docker run --rm --privileged --net=host \
+    docker run --rm --privileged --net=host -u $(id -u):$(id -g) \
            --name $CONTAINER_NAME --security-opt seccomp=unconfined \
-           -e DISPLAY -e XAUTHORITY=$XAUTH $DOCKER_OPTS \
-           -e PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native \
+           -e DISPLAY -e MESA_GL_VERSION_OVERRIDE=3.3 -e XAUTHORITY=$XAUTH \
+           $DOCKER_OPTS -e PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native \
            -v $XDG_RUNTIME_DIR/pulse/native:$XDG_RUNTIME_DIR/pulse/native \
            -v $HOME/.config/pulse/cookie:$HOME/.config/pulse/cookie \
            -v "$XAUTH:$XAUTH" -v /tmp/.X11-unix:/tmp/.X11-unix:ro \


### PR DESCRIPTION
Turns out SEGAFAULTs within `gz-common5` in containers were due to bad permissions and misleading error handling (or lack thereof). This patch allows `fixuid` to run recursively on $HOME by `root`ing any pre-built workspace as if it were a system dependency.